### PR TITLE
feat: prijs per m² prominent weergeven

### DIFF
--- a/backend/api/watchlist.py
+++ b/backend/api/watchlist.py
@@ -50,6 +50,7 @@ class WatchlistItemResponse(WatchlistItemBase):
     # Embedded woning info
     woning_adres: Optional[str] = None
     woning_vraagprijs: Optional[int] = None
+    woning_woonoppervlakte: Optional[int] = None
     woning_status: Optional[str] = None
 
     class Config:
@@ -94,6 +95,7 @@ def list_watchlist(
             updated_at=item.updated_at,
             woning_adres=woning.adres if woning else None,
             woning_vraagprijs=woning.vraagprijs if woning else None,
+            woning_woonoppervlakte=woning.woonoppervlakte if woning else None,
             woning_status=woning.status if woning else None,
         )
         result.append(response)
@@ -125,6 +127,7 @@ def get_watchlist_item(item_id: int, db: Session = Depends(get_db)):
         updated_at=item.updated_at,
         woning_adres=woning.adres if woning else None,
         woning_vraagprijs=woning.vraagprijs if woning else None,
+        woning_woonoppervlakte=woning.woonoppervlakte if woning else None,
         woning_status=woning.status if woning else None,
     )
 
@@ -174,6 +177,7 @@ def create_watchlist_item(item: WatchlistItemCreate, db: Session = Depends(get_d
         updated_at=db_item.updated_at,
         woning_adres=woning.adres,
         woning_vraagprijs=woning.vraagprijs,
+        woning_woonoppervlakte=woning.woonoppervlakte,
         woning_status=woning.status,
     )
 
@@ -218,6 +222,7 @@ def update_watchlist_item(
         updated_at=item.updated_at,
         woning_adres=woning.adres if woning else None,
         woning_vraagprijs=woning.vraagprijs if woning else None,
+        woning_woonoppervlakte=woning.woonoppervlakte if woning else None,
         woning_status=woning.status if woning else None,
     )
 

--- a/frontend/src/pages/WatchlistPage.tsx
+++ b/frontend/src/pages/WatchlistPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   fetchWatchlist,
@@ -59,8 +60,15 @@ function WatchlistCard({
         <div>
           <h3 className="font-semibold text-gray-900">{item.woning_adres}</h3>
           {item.woning_vraagprijs && (
-            <div className="text-primary-700 font-medium">
-              {formatPrijs(item.woning_vraagprijs)}
+            <div>
+              <div className="text-primary-700 font-medium">
+                {formatPrijs(item.woning_vraagprijs)}
+              </div>
+              {item.woning_woonoppervlakte && item.woning_woonoppervlakte > 0 && (
+                <div className="text-sm font-medium text-primary-600">
+                  {formatPrijs(Math.round(item.woning_vraagprijs / item.woning_woonoppervlakte))}/m²
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -106,8 +114,11 @@ function WatchlistCard({
   )
 }
 
+type SortOption = 'prioriteit' | 'prijs' | 'prijs_m2'
+
 export default function WatchlistPage() {
   const queryClient = useQueryClient()
+  const [sortBy, setSortBy] = useState<SortOption>('prioriteit')
 
   const { data: items, isLoading, error } = useQuery({
     queryKey: ['watchlist'],
@@ -158,7 +169,22 @@ export default function WatchlistPage() {
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900 mb-2">Watchlist</h1>
-      <p className="text-gray-600 mb-8">Volg woningen die je interessant vindt</p>
+      <p className="text-gray-600 mb-4">Volg woningen die je interessant vindt</p>
+
+      {items && items.length > 0 && (
+        <div className="flex items-center gap-2 mb-6">
+          <span className="text-sm text-gray-600">Sorteer op:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as SortOption)}
+            className="text-sm border border-gray-300 rounded px-2 py-1"
+          >
+            <option value="prioriteit">Prioriteit</option>
+            <option value="prijs">Prijs</option>
+            <option value="prijs_m2">Prijs/m² (laag → hoog)</option>
+          </select>
+        </div>
+      )}
 
       {isLoading && (
         <div className="text-center py-12 text-gray-500">Watchlist laden...</div>
@@ -192,7 +218,19 @@ export default function WatchlistPage() {
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {statusItems
-                    .sort((a, b) => b.prioriteit - a.prioriteit)
+                    .sort((a, b) => {
+                      if (sortBy === 'prijs') {
+                        return (b.woning_vraagprijs || 0) - (a.woning_vraagprijs || 0)
+                      }
+                      if (sortBy === 'prijs_m2') {
+                        const aM2 = a.woning_vraagprijs && a.woning_woonoppervlakte
+                          ? a.woning_vraagprijs / a.woning_woonoppervlakte : 0
+                        const bM2 = b.woning_vraagprijs && b.woning_woonoppervlakte
+                          ? b.woning_vraagprijs / b.woning_woonoppervlakte : 0
+                        return aM2 - bM2
+                      }
+                      return b.prioriteit - a.prioriteit
+                    })
                     .map((item) => (
                       <WatchlistCard
                         key={item.id}

--- a/frontend/src/pages/WoningenPage.tsx
+++ b/frontend/src/pages/WoningenPage.tsx
@@ -30,7 +30,7 @@ function WoningCard({ woning, onAddToWatchlist }: {
         {woning.vraagprijs && (
           <div className="text-right">
             <div className="font-bold text-primary-700">{formatPrijs(woning.vraagprijs)}</div>
-            {m2Prijs && <div className="text-xs text-gray-500">{formatPrijs(m2Prijs)}/m²</div>}
+            {m2Prijs && <div className="text-sm font-medium text-primary-600">{formatPrijs(m2Prijs)}/m²</div>}
           </div>
         )}
       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -174,6 +174,7 @@ export interface WatchlistItem {
   status: string
   woning_adres?: string
   woning_vraagprijs?: number
+  woning_woonoppervlakte?: number
   added_at: string
 }
 


### PR DESCRIPTION
## Summary
- Prijs per m² prominenter weergeven op WoningenPage (grotere tekst, primary kleur)
- Prijs per m² toegevoegd op WatchlistPage onder de vraagprijs
- Sorteeroptie toegevoegd op WatchlistPage: prioriteit, prijs, of prijs/m²
- Backend watchlist API geeft nu ook `woning_woonoppervlakte` mee

## Test plan
- [ ] WoningenPage: controleer dat m²-prijs prominent zichtbaar is bij woningen met prijs + oppervlakte
- [ ] WatchlistPage: controleer dat m²-prijs onder de vraagprijs staat
- [ ] WatchlistPage: test sorteren op prioriteit, prijs, en prijs/m²
- [ ] API: GET /api/watchlist response bevat `woning_woonoppervlakte`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)