### PR TITLE
feat: vereenvoudig WaardebepalingPage (#28)

### DIFF
--- a/backend/api/woningen.py
+++ b/backend/api/woningen.py
@@ -205,6 +205,11 @@ class EnhancedWaardebepalingResponse(BaseModel):
     woz_peiljaar: Optional[int] = None
     grondoppervlakte: Optional[int] = None
 
+    # Woninggegevens (auto-fetched)
+    woonoppervlakte: Optional[int] = None
+    bouwjaar: Optional[int] = None
+    woningtype: Optional[str] = None
+
     # Energielabel (auto-fetched)
     energielabel: Optional[str] = None
     energielabel_bron: str = "auto"  # "auto" or "manual"
@@ -805,6 +810,10 @@ def bereken_waarde_voor_adres(
         woz_waarde=woz_result.woz_waarde if woz_result else None,
         woz_peiljaar=woz_result.peiljaar if woz_result else None,
         grondoppervlakte=grondoppervlakte,
+        # Woninggegevens
+        woonoppervlakte=woonoppervlakte,
+        bouwjaar=bouwjaar,
+        woningtype=request.woningtype,
         # Energielabel
         energielabel=energielabel,
         energielabel_bron="auto" if energielabel else "niet_gevonden",

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -1,22 +1,12 @@
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import {
-  berekenWaarde,
   berekenWaardeVoorAdres,
-  WaardebepalingRequest,
   EnhancedWaardebepalingRequest,
+  EnhancedWaardebepalingResponse,
   formatPrijs,
   formatM2Prijs,
 } from '../services/api'
-
-const ENERGY_LABELS = ['A++++', 'A+++', 'A++', 'A+', 'A', 'B', 'C', 'D', 'E', 'F', 'G']
-const PROPERTY_TYPES = [
-  { value: 'appartement', label: 'Appartement' },
-  { value: 'tussenwoning', label: 'Tussenwoning' },
-  { value: 'hoekwoning', label: 'Hoekwoning' },
-  { value: 'twee-onder-een-kap', label: 'Twee-onder-een-kap' },
-  { value: 'vrijstaand', label: 'Vrijstaand' },
-]
 
 function BiedAdviesBadge({ advies }: { advies: string }) {
   const colors: Record<string, string> = {
@@ -81,177 +71,6 @@ function EnergyLabelBadge({ label }: { label: string }) {
   )
 }
 
-function WOZCard({
-  wozWaarde,
-  peiljaar,
-  grondoppervlakte,
-}: {
-  wozWaarde?: number
-  peiljaar?: number
-  grondoppervlakte?: number
-}) {
-  if (!wozWaarde && !grondoppervlakte) return null
-
-  return (
-    <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-      <div className="flex items-center justify-between">
-        <div>
-          {wozWaarde && (
-            <>
-              <div className="text-sm text-blue-600 font-medium">WOZ-waarde</div>
-              <div className="text-lg font-semibold text-blue-800">{formatPrijs(wozWaarde)}</div>
-            </>
-          )}
-        </div>
-        <div className="text-right">
-          {peiljaar && (
-            <div className="text-sm text-blue-500">
-              Peildatum: 1 jan {peiljaar}
-            </div>
-          )}
-          {grondoppervlakte && (
-            <div className="text-sm text-blue-600 mt-1">
-              Perceel: <span className="font-medium">{grondoppervlakte} m²</span>
-            </div>
-          )}
-        </div>
-      </div>
-      <p className="text-xs text-blue-600 mt-2">
-        De WOZ-waarde is de waarde voor belastingdoeleinden, bepaald door de gemeente.
-      </p>
-    </div>
-  )
-}
-
-function ComparablesCard({
-  count,
-  avgM2,
-}: {
-  count: number
-  avgM2?: number
-}) {
-  return (
-    <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
-      <div className="text-sm text-purple-600 font-medium">Vergelijkbare verkopen</div>
-      {count > 0 ? (
-        <div className="mt-1">
-          <span className="text-lg font-semibold text-purple-800">{count}</span>
-          <span className="text-purple-600 text-sm ml-1">recent verkochte woningen in de buurt</span>
-          {avgM2 && (
-            <div className="text-sm text-purple-700 mt-1">
-              Gem. {formatM2Prijs(avgM2)}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="text-sm text-purple-600 mt-1">
-          Geen recente transacties gevonden
-        </div>
-      )}
-    </div>
-  )
-}
-
-function MarktIndicatorenCard({
-  gemPrijs,
-  overbiedPct,
-  verkooptijd,
-  peildatum,
-}: {
-  gemPrijs?: number
-  overbiedPct?: number
-  verkooptijd?: number
-  peildatum?: string
-}) {
-  if (!gemPrijs && !overbiedPct && !verkooptijd) return null
-
-  return (
-    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-      <div className="flex items-center justify-between mb-2">
-        <div className="text-sm text-amber-700 font-medium">Marktindicatoren regio</div>
-        {peildatum && (
-          <div className="text-xs text-amber-500">{peildatum}</div>
-        )}
-      </div>
-      <div className="grid grid-cols-3 gap-3">
-        {gemPrijs && (
-          <div>
-            <div className="text-xs text-amber-600">Gem. verkoopprijs</div>
-            <div className="text-sm font-semibold text-amber-800">{formatPrijs(gemPrijs)}</div>
-          </div>
-        )}
-        {overbiedPct !== undefined && overbiedPct !== null && (
-          <div>
-            <div className="text-xs text-amber-600">Overbieden</div>
-            <div className={`text-sm font-semibold ${overbiedPct >= 0 ? 'text-red-600' : 'text-green-600'}`}>
-              {overbiedPct >= 0 ? '+' : ''}{overbiedPct.toFixed(1)}%
-            </div>
-          </div>
-        )}
-        {verkooptijd && (
-          <div>
-            <div className="text-xs text-amber-600">Gem. verkooptijd</div>
-            <div className="text-sm font-semibold text-amber-800">{verkooptijd} dagen</div>
-          </div>
-        )}
-      </div>
-      <p className="text-xs text-amber-600 mt-2">
-        Bron: CBS StatLine
-      </p>
-    </div>
-  )
-}
-
-function BuurtCard({
-  buurtNaam,
-  gemWoz,
-  koopwoningenPct,
-  gemInkomen,
-}: {
-  buurtNaam?: string
-  gemWoz?: number
-  koopwoningenPct?: number
-  gemInkomen?: number
-}) {
-  if (!buurtNaam && !gemWoz) return null
-
-  return (
-    <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
-      <div className="flex items-center justify-between mb-2">
-        <div className="text-sm text-teal-700 font-medium">Buurtindicatoren</div>
-        {buurtNaam && (
-          <div className="text-xs text-teal-600 truncate max-w-[180px]" title={buurtNaam}>
-            {buurtNaam}
-          </div>
-        )}
-      </div>
-      <div className="grid grid-cols-3 gap-3">
-        {gemWoz && (
-          <div>
-            <div className="text-xs text-teal-600">Gem. WOZ buurt</div>
-            <div className="text-sm font-semibold text-teal-800">{formatPrijs(gemWoz)}</div>
-          </div>
-        )}
-        {koopwoningenPct !== undefined && koopwoningenPct !== null && (
-          <div>
-            <div className="text-xs text-teal-600">Koopwoningen</div>
-            <div className="text-sm font-semibold text-teal-800">{koopwoningenPct.toFixed(0)}%</div>
-          </div>
-        )}
-        {gemInkomen && (
-          <div>
-            <div className="text-xs text-teal-600">Gem. inkomen</div>
-            <div className="text-sm font-semibold text-teal-800">{formatPrijs(gemInkomen)}</div>
-          </div>
-        )}
-      </div>
-      <p className="text-xs text-teal-600 mt-2">
-        Bron: CBS Kerncijfers wijken en buurten
-      </p>
-    </div>
-  )
-}
-
 function DataBronnenFooter({ bronnen }: { bronnen: string[] }) {
   if (!bronnen || bronnen.length === 0) return null
 
@@ -272,29 +91,320 @@ function DataBronnenFooter({ bronnen }: { bronnen: string[] }) {
   )
 }
 
-type Mode = 'simple' | 'address'
+function WoningGegevensColumn({ result }: { result: EnhancedWaardebepalingResponse }) {
+  const WONINGTYPE_LABELS: Record<string, string> = {
+    appartement: 'Appartement',
+    tussenwoning: 'Tussenwoning',
+    hoekwoning: 'Hoekwoning',
+    'twee-onder-een-kap': 'Twee-onder-een-kap',
+    vrijstaand: 'Vrijstaand',
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Woninggegevens</h2>
+
+      {/* Adres */}
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="text-sm text-gray-500">Adres</div>
+        <div className="text-lg font-medium">{result.adres || `${result.postcode} ${result.huisnummer}`}</div>
+      </div>
+
+      {/* Kenmerken */}
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="text-sm text-gray-500 font-medium mb-3">Kenmerken</div>
+        <dl className="space-y-2 text-sm">
+          {result.woonoppervlakte && (
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Woonoppervlakte</dt>
+              <dd className="font-medium">{result.woonoppervlakte} m²</dd>
+            </div>
+          )}
+          {result.grondoppervlakte && (
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Grondoppervlakte</dt>
+              <dd className="font-medium">{result.grondoppervlakte} m²</dd>
+            </div>
+          )}
+          {result.bouwjaar && (
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Bouwjaar</dt>
+              <dd className="font-medium">{result.bouwjaar}</dd>
+            </div>
+          )}
+          {result.woningtype && (
+            <div className="flex justify-between">
+              <dt className="text-gray-600">Woningtype</dt>
+              <dd className="font-medium">{WONINGTYPE_LABELS[result.woningtype] || result.woningtype}</dd>
+            </div>
+          )}
+          <div className="flex justify-between items-center">
+            <dt className="text-gray-600">Energielabel</dt>
+            <dd>
+              {result.energielabel ? (
+                <div className="flex items-center gap-2">
+                  <EnergyLabelBadge label={result.energielabel} />
+                  <span className="text-xs text-gray-400">({result.energielabel_bron === 'auto' ? 'EP-Online' : result.energielabel_bron})</span>
+                </div>
+              ) : (
+                <span className="text-gray-400">Niet gevonden</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* WOZ-waarde */}
+      {(result.woz_waarde || result.grondoppervlakte) && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="flex items-center justify-between">
+            <div>
+              {result.woz_waarde && (
+                <>
+                  <div className="text-sm text-blue-600 font-medium">WOZ-waarde</div>
+                  <div className="text-lg font-semibold text-blue-800">{formatPrijs(result.woz_waarde)}</div>
+                </>
+              )}
+            </div>
+            {result.woz_peiljaar && (
+              <div className="text-sm text-blue-500 text-right">
+                Peildatum: 1 jan {result.woz_peiljaar}
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-blue-600 mt-2">
+            De WOZ-waarde is de waarde voor belastingdoeleinden, bepaald door de gemeente.
+          </p>
+        </div>
+      )}
+
+      {/* Buurtgegevens */}
+      {(result.buurt_naam || result.buurt_gem_woz) && (
+        <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-sm text-teal-700 font-medium">Buurtindicatoren</div>
+            {result.buurt_naam && (
+              <div className="text-xs text-teal-600 truncate max-w-[180px]" title={result.buurt_naam}>
+                {result.buurt_naam}
+              </div>
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {result.buurt_gem_woz && (
+              <div>
+                <div className="text-xs text-teal-600">Gem. WOZ buurt</div>
+                <div className="text-sm font-semibold text-teal-800">{formatPrijs(result.buurt_gem_woz)}</div>
+              </div>
+            )}
+            {result.buurt_koopwoningen_pct !== undefined && result.buurt_koopwoningen_pct !== null && (
+              <div>
+                <div className="text-xs text-teal-600">Koopwoningen</div>
+                <div className="text-sm font-semibold text-teal-800">{result.buurt_koopwoningen_pct.toFixed(0)}%</div>
+              </div>
+            )}
+            {result.buurt_gem_inkomen && (
+              <div>
+                <div className="text-xs text-teal-600">Gem. inkomen</div>
+                <div className="text-sm font-semibold text-teal-800">{formatPrijs(result.buurt_gem_inkomen)}</div>
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-teal-600 mt-2">
+            Bron: CBS Kerncijfers wijken en buurten
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AnalyseColumn({ result, onCopy, copied }: {
+  result: EnhancedWaardebepalingResponse
+  onCopy: (waarde: number) => void
+  copied: boolean
+}) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Analyse & Advies</h2>
+
+      {/* Geschatte waarde */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="text-center">
+          <div className="text-sm text-gray-500 mb-1">Geschatte marktwaarde</div>
+          <div className="text-4xl font-bold text-primary-700">
+            {formatPrijs(result.waarde_midden)}
+          </div>
+          <div className="text-gray-500 mt-1">
+            {formatPrijs(result.waarde_laag)} - {formatPrijs(result.waarde_hoog)}
+          </div>
+        </div>
+
+        <ConfidenceBar confidence={result.confidence} />
+
+        {result.vraagprijs && (
+          <div className="mt-4 pt-4 border-t">
+            <div className="flex justify-between items-center">
+              <span className="text-gray-600">Vraagprijs</span>
+              <span className="font-medium">{formatPrijs(result.vraagprijs)}</span>
+            </div>
+            {result.verschil_percentage !== null && result.verschil_percentage !== undefined && (
+              <div className="flex justify-between items-center mt-1">
+                <span className="text-gray-600">Verschil</span>
+                <span
+                  className={
+                    result.verschil_percentage > 0
+                      ? 'text-red-600 font-medium'
+                      : 'text-green-600 font-medium'
+                  }
+                >
+                  {result.verschil_percentage > 0 ? '+' : ''}
+                  {result.verschil_percentage.toFixed(1)}%
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Biedadvies */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold mb-4">Biedadvies</h3>
+        <div className="flex items-center justify-between">
+          <BiedAdviesBadge advies={result.bied_advies} />
+        </div>
+        <div className="mt-4 bg-gray-50 rounded-lg p-4">
+          <div className="text-sm text-gray-600">Aanbevolen biedingsbereik</div>
+          <div className="flex items-center justify-between">
+            <div className="text-xl font-semibold">
+              {formatPrijs(result.bied_range_laag)} - {formatPrijs(result.bied_range_hoog)}
+            </div>
+            <button
+              onClick={() => onCopy(result.waarde_midden)}
+              className="px-3 py-1 text-sm font-medium rounded-lg bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
+            >
+              {copied ? 'Gekopieerd!' : 'Kopieer bedrag'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Vergelijkbare verkopen */}
+      <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
+        <div className="text-sm text-purple-600 font-medium">Vergelijkbare verkopen</div>
+        {result.comparables_count > 0 ? (
+          <div className="mt-1">
+            <span className="text-lg font-semibold text-purple-800">{result.comparables_count}</span>
+            <span className="text-purple-600 text-sm ml-1">recent verkochte woningen in de buurt</span>
+            {result.comparables_avg_m2 && (
+              <div className="text-sm text-purple-700 mt-1">
+                Gem. {formatM2Prijs(result.comparables_avg_m2)}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="text-sm text-purple-600 mt-1">
+            Geen recente transacties gevonden
+          </div>
+        )}
+      </div>
+
+      {/* Marktindicatoren */}
+      {(result.markt_gem_prijs || result.markt_overbiedpct || result.markt_verkooptijd) && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-sm text-amber-700 font-medium">Marktindicatoren regio</div>
+            {result.markt_peildatum && (
+              <div className="text-xs text-amber-500">{result.markt_peildatum}</div>
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            {result.markt_gem_prijs && (
+              <div>
+                <div className="text-xs text-amber-600">Gem. verkoopprijs</div>
+                <div className="text-sm font-semibold text-amber-800">{formatPrijs(result.markt_gem_prijs)}</div>
+              </div>
+            )}
+            {result.markt_overbiedpct !== undefined && result.markt_overbiedpct !== null && (
+              <div>
+                <div className="text-xs text-amber-600">Overbieden</div>
+                <div className={`text-sm font-semibold ${result.markt_overbiedpct >= 0 ? 'text-red-600' : 'text-green-600'}`}>
+                  {result.markt_overbiedpct >= 0 ? '+' : ''}{result.markt_overbiedpct.toFixed(1)}%
+                </div>
+              </div>
+            )}
+            {result.markt_verkooptijd && (
+              <div>
+                <div className="text-xs text-amber-600">Gem. verkooptijd</div>
+                <div className="text-sm font-semibold text-amber-800">{result.markt_verkooptijd} dagen</div>
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-amber-600 mt-2">
+            Bron: CBS StatLine
+          </p>
+        </div>
+      )}
+
+      {/* Opbouw schatting */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold mb-4">Opbouw schatting</h3>
+        <div className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-gray-600">Basiswaarde (m² x buurtprijs)</span>
+            <span>{formatPrijs(result.basis_waarde)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Energielabel correctie</span>
+            <span className={result.energielabel_correctie >= 0 ? 'text-green-600' : 'text-red-600'}>
+              {result.energielabel_correctie >= 0 ? '+' : ''}{formatPrijs(result.energielabel_correctie)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Bouwjaar correctie</span>
+            <span className={result.bouwjaar_correctie >= 0 ? 'text-green-600' : 'text-red-600'}>
+              {result.bouwjaar_correctie >= 0 ? '+' : ''}{formatPrijs(result.bouwjaar_correctie)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Woningtype correctie</span>
+            <span className={result.woningtype_correctie >= 0 ? 'text-green-600' : 'text-red-600'}>
+              {result.woningtype_correctie >= 0 ? '+' : ''}{formatPrijs(result.woningtype_correctie)}
+            </span>
+          </div>
+          {result.perceel_correctie !== 0 && (
+            <div className="flex justify-between">
+              <span className="text-gray-600">Perceelgrootte correctie</span>
+              <span className={result.perceel_correctie >= 0 ? 'text-green-600' : 'text-red-600'}>
+                {result.perceel_correctie >= 0 ? '+' : ''}{formatPrijs(result.perceel_correctie)}
+              </span>
+            </div>
+          )}
+          <div className="flex justify-between">
+            <span className="text-gray-600">Marktcorrectie (overbieden)</span>
+            <span className="text-green-600">
+              +{formatPrijs(result.markt_correctie)}
+            </span>
+          </div>
+          <div className="flex justify-between pt-2 border-t font-semibold">
+            <span>Totaal</span>
+            <span>{formatPrijs(result.waarde_midden)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Databronnen */}
+      <DataBronnenFooter bronnen={result.data_bronnen} />
+    </div>
+  )
+}
 
 export default function WaardebepalingPage() {
-  const [mode, setMode] = useState<Mode>('address')
-
-  // Simple mode form data
-  const [simpleFormData, setSimpleFormData] = useState<WaardebepalingRequest>({
-    woonoppervlakte: 100,
-    energielabel: 'C',
-    bouwjaar: 1980,
-    woningtype: 'tussenwoning',
-    vraagprijs: undefined,
-  })
-
-  // Address mode form data
-  const [addressFormData, setAddressFormData] = useState<EnhancedWaardebepalingRequest>({
+  const [formData, setFormData] = useState<EnhancedWaardebepalingRequest>({
     postcode: '',
     huisnummer: 0,
     huisletter: undefined,
     toevoeging: undefined,
-    woonoppervlakte: undefined,
     vraagprijs: undefined,
-    woningtype: undefined,
   })
 
   const [copied, setCopied] = useState(false)
@@ -305,657 +415,152 @@ export default function WaardebepalingPage() {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  // Simple mode mutation
-  const simpleMutation = useMutation({
-    mutationFn: berekenWaarde,
-  })
-
-  // Address mode mutation
-  const addressMutation = useMutation({
+  const mutation = useMutation({
     mutationFn: berekenWaardeVoorAdres,
   })
 
-  const handleSimpleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    simpleMutation.mutate(simpleFormData)
+    mutation.mutate(formData)
   }
 
-  const handleAddressSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    addressMutation.mutate(addressFormData)
-  }
-
-  const simpleResult = simpleMutation.data
-  const addressResult = addressMutation.data
-  const isPending = simpleMutation.isPending || addressMutation.isPending
-  const isError = simpleMutation.isError || addressMutation.isError
-  const error = simpleMutation.error || addressMutation.error
+  const result = mutation.data
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-6xl mx-auto">
       <h1 className="text-3xl font-bold text-gray-900 mb-2">Waardebepaling</h1>
       <p className="text-gray-600 mb-6">
         Bereken de geschatte marktwaarde en krijg biedadvies
       </p>
 
-      {/* Mode selector */}
-      <div className="flex space-x-2 mb-6">
-        <button
-          onClick={() => setMode('address')}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-            mode === 'address'
-              ? 'bg-primary-600 text-white'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-          }`}
-        >
-          Op basis van adres
-        </button>
-        <button
-          onClick={() => setMode('simple')}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-            mode === 'simple'
-              ? 'bg-primary-600 text-white'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-          }`}
-        >
-          Handmatig invoeren
-        </button>
+      {/* Zoekformulier */}
+      <div className="bg-white rounded-lg shadow p-6 mb-8">
+        <form onSubmit={handleSubmit}>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Postcode *
+              </label>
+              <input
+                type="text"
+                required
+                placeholder="1234 AB"
+                maxLength={7}
+                value={formData.postcode}
+                onChange={(e) =>
+                  setFormData({ ...formData, postcode: e.target.value.toUpperCase() })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Huisnummer *
+              </label>
+              <input
+                type="number"
+                required
+                min={1}
+                value={formData.huisnummer || ''}
+                onChange={(e) =>
+                  setFormData({ ...formData, huisnummer: Number(e.target.value) })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Huisletter
+              </label>
+              <input
+                type="text"
+                maxLength={2}
+                placeholder="A"
+                value={formData.huisletter || ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    huisletter: e.target.value.toUpperCase() || undefined,
+                  })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Toevoeging
+              </label>
+              <input
+                type="text"
+                maxLength={10}
+                placeholder="bis, 2"
+                value={formData.toevoeging || ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    toevoeging: e.target.value || undefined,
+                  })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Vraagprijs
+              </label>
+              <input
+                type="number"
+                min={0}
+                step={1000}
+                value={formData.vraagprijs || ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    vraagprijs: e.target.value ? Number(e.target.value) : undefined,
+                  })
+                }
+                placeholder="450000"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+            </div>
+            <div className="flex items-end">
+              <button
+                type="submit"
+                disabled={mutation.isPending}
+                className="w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50"
+              >
+                {mutation.isPending ? 'Ophalen...' : 'Zoek waarde'}
+              </button>
+            </div>
+          </div>
+        </form>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* Form */}
-        <div className="bg-white rounded-lg shadow p-6">
-          {mode === 'address' ? (
-            <>
-              <h2 className="text-lg font-semibold mb-4">Adresgegevens</h2>
-              <p className="text-sm text-gray-500 mb-4">
-                Voer het adres in en we halen automatisch WOZ-waarde, energielabel en vergelijkbare verkopen op.
-              </p>
-              <form onSubmit={handleAddressSubmit} className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Postcode *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      placeholder="1234 AB"
-                      maxLength={7}
-                      value={addressFormData.postcode}
-                      onChange={(e) =>
-                        setAddressFormData({ ...addressFormData, postcode: e.target.value.toUpperCase() })
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Huisnummer *
-                    </label>
-                    <input
-                      type="number"
-                      required
-                      min={1}
-                      value={addressFormData.huisnummer || ''}
-                      onChange={(e) =>
-                        setAddressFormData({ ...addressFormData, huisnummer: Number(e.target.value) })
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Huisletter
-                    </label>
-                    <input
-                      type="text"
-                      maxLength={2}
-                      placeholder="A"
-                      value={addressFormData.huisletter || ''}
-                      onChange={(e) =>
-                        setAddressFormData({
-                          ...addressFormData,
-                          huisletter: e.target.value.toUpperCase() || undefined,
-                        })
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Toevoeging
-                    </label>
-                    <input
-                      type="text"
-                      maxLength={10}
-                      placeholder="bis, 2"
-                      value={addressFormData.toevoeging || ''}
-                      onChange={(e) =>
-                        setAddressFormData({
-                          ...addressFormData,
-                          toevoeging: e.target.value || undefined,
-                        })
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Woonoppervlakte (m²)
-                  </label>
-                  <input
-                    type="number"
-                    min={1}
-                    max={1000}
-                    placeholder="Wordt automatisch opgehaald"
-                    value={addressFormData.woonoppervlakte || ''}
-                    onChange={(e) =>
-                      setAddressFormData({
-                        ...addressFormData,
-                        woonoppervlakte: e.target.value ? Number(e.target.value) : undefined,
-                      })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Wordt opgehaald uit BAG. Vul in als backup.
-                  </p>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Vraagprijs (optioneel)
-                  </label>
-                  <input
-                    type="number"
-                    min={0}
-                    step={1000}
-                    value={addressFormData.vraagprijs || ''}
-                    onChange={(e) =>
-                      setAddressFormData({
-                        ...addressFormData,
-                        vraagprijs: e.target.value ? Number(e.target.value) : undefined,
-                      })
-                    }
-                    placeholder="bijv. 450000"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Woningtype (optioneel)
-                  </label>
-                  <select
-                    value={addressFormData.woningtype || ''}
-                    onChange={(e) =>
-                      setAddressFormData({ ...addressFormData, woningtype: e.target.value || undefined })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  >
-                    <option value="">Onbekend</option>
-                    {PROPERTY_TYPES.map((type) => (
-                      <option key={type.value} value={type.value}>
-                        {type.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={isPending}
-                  className="w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50"
-                >
-                  {isPending ? 'Gegevens ophalen...' : 'Bereken waarde'}
-                </button>
-              </form>
-            </>
-          ) : (
-            <>
-              <h2 className="text-lg font-semibold mb-4">Woninggegevens</h2>
-              <form onSubmit={handleSimpleSubmit} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Woonoppervlakte (m²) *
-                  </label>
-                  <input
-                    type="number"
-                    required
-                    min={1}
-                    max={1000}
-                    value={simpleFormData.woonoppervlakte}
-                    onChange={(e) =>
-                      setSimpleFormData({ ...simpleFormData, woonoppervlakte: Number(e.target.value) })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Vraagprijs (optioneel)
-                  </label>
-                  <input
-                    type="number"
-                    min={0}
-                    step={1000}
-                    value={simpleFormData.vraagprijs || ''}
-                    onChange={(e) =>
-                      setSimpleFormData({
-                        ...simpleFormData,
-                        vraagprijs: e.target.value ? Number(e.target.value) : undefined,
-                      })
-                    }
-                    placeholder="bijv. 450000"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Energielabel
-                  </label>
-                  <select
-                    value={simpleFormData.energielabel || ''}
-                    onChange={(e) =>
-                      setSimpleFormData({ ...simpleFormData, energielabel: e.target.value || undefined })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  >
-                    <option value="">Onbekend</option>
-                    {ENERGY_LABELS.map((label) => (
-                      <option key={label} value={label}>
-                        {label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Bouwjaar
-                  </label>
-                  <input
-                    type="number"
-                    min={1500}
-                    max={2030}
-                    value={simpleFormData.bouwjaar || ''}
-                    onChange={(e) =>
-                      setSimpleFormData({
-                        ...simpleFormData,
-                        bouwjaar: e.target.value ? Number(e.target.value) : undefined,
-                      })
-                    }
-                    placeholder="bijv. 1985"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Woningtype
-                  </label>
-                  <select
-                    value={simpleFormData.woningtype || ''}
-                    onChange={(e) =>
-                      setSimpleFormData({ ...simpleFormData, woningtype: e.target.value || undefined })
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  >
-                    <option value="">Onbekend</option>
-                    {PROPERTY_TYPES.map((type) => (
-                      <option key={type.value} value={type.value}>
-                        {type.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={isPending}
-                  className="w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50"
-                >
-                  {isPending ? 'Berekenen...' : 'Bereken waarde'}
-                </button>
-              </form>
-            </>
-          )}
+      {/* Error */}
+      {mutation.isError && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 mb-8">
+          {mutation.error instanceof Error ? mutation.error.message : 'Er is een fout opgetreden bij het berekenen van de waarde.'}
         </div>
+      )}
 
-        {/* Results */}
-        <div>
-          {isError && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 mb-4">
-              {error instanceof Error ? error.message : 'Er is een fout opgetreden bij het berekenen van de waarde.'}
-            </div>
-          )}
-
-          {/* Address mode results */}
-          {addressResult && mode === 'address' && (
-            <div className="space-y-4">
-              {/* Address header */}
-              <div className="bg-gray-50 rounded-lg p-4">
-                <div className="flex justify-between items-start">
-                  <div>
-                    <div className="text-sm text-gray-500">Adres</div>
-                    <div className="text-lg font-medium">{addressResult.adres}</div>
-                  </div>
-                  <div className="text-xs text-gray-400">via BAG</div>
-                </div>
-              </div>
-
-              {/* WOZ value */}
-              <WOZCard
-                wozWaarde={addressResult.woz_waarde}
-                peiljaar={addressResult.woz_peiljaar}
-                grondoppervlakte={addressResult.grondoppervlakte}
-              />
-
-              {/* Comparables summary */}
-              <ComparablesCard
-                count={addressResult.comparables_count}
-                avgM2={addressResult.comparables_avg_m2}
-              />
-
-              {/* Market indicators */}
-              <MarktIndicatorenCard
-                gemPrijs={addressResult.markt_gem_prijs}
-                overbiedPct={addressResult.markt_overbiedpct}
-                verkooptijd={addressResult.markt_verkooptijd}
-                peildatum={addressResult.markt_peildatum}
-              />
-
-              {/* Buurt indicators */}
-              <BuurtCard
-                buurtNaam={addressResult.buurt_naam}
-                gemWoz={addressResult.buurt_gem_woz}
-                koopwoningenPct={addressResult.buurt_koopwoningen_pct}
-                gemInkomen={addressResult.buurt_gem_inkomen}
-              />
-
-              {/* Main result */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Geschatte waarde</h2>
-                <div className="text-center">
-                  <div className="text-4xl font-bold text-primary-700">
-                    {formatPrijs(addressResult.waarde_midden)}
-                  </div>
-                  <div className="text-gray-500 mt-1">
-                    {formatPrijs(addressResult.waarde_laag)} - {formatPrijs(addressResult.waarde_hoog)}
-                  </div>
-                </div>
-
-                {/* Energielabel */}
-                <div className="flex items-center justify-center mt-4 space-x-2">
-                  <span className="text-sm text-gray-600">Energielabel:</span>
-                  {addressResult.energielabel ? (
-                    <>
-                      <EnergyLabelBadge label={addressResult.energielabel} />
-                      <span className="text-xs text-green-600">(EP-Online)</span>
-                    </>
-                  ) : (
-                    <span className="text-sm text-gray-400">Niet gevonden in EP-Online</span>
-                  )}
-                </div>
-
-                <ConfidenceBar confidence={addressResult.confidence} />
-
-                {addressResult.vraagprijs && (
-                  <div className="mt-4 pt-4 border-t">
-                    <div className="flex justify-between items-center">
-                      <span className="text-gray-600">Vraagprijs</span>
-                      <span className="font-medium">{formatPrijs(addressResult.vraagprijs)}</span>
-                    </div>
-                    {addressResult.verschil_percentage !== null && addressResult.verschil_percentage !== undefined && (
-                      <div className="flex justify-between items-center mt-1">
-                        <span className="text-gray-600">Verschil</span>
-                        <span
-                          className={
-                            addressResult.verschil_percentage > 0
-                              ? 'text-red-600 font-medium'
-                              : 'text-green-600 font-medium'
-                          }
-                        >
-                          {addressResult.verschil_percentage > 0 ? '+' : ''}
-                          {addressResult.verschil_percentage.toFixed(1)}%
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Bid advice */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Biedadvies</h2>
-                <div className="flex items-center justify-between">
-                  <BiedAdviesBadge advies={addressResult.bied_advies} />
-                </div>
-                <div className="mt-4 bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-600">Aanbevolen biedingsbereik</div>
-                  <div className="flex items-center justify-between">
-                    <div className="text-xl font-semibold">
-                      {formatPrijs(addressResult.bied_range_laag)} - {formatPrijs(addressResult.bied_range_hoog)}
-                    </div>
-                    <button
-                      onClick={() => handleCopy(addressResult.waarde_midden)}
-                      className="px-3 py-1 text-sm font-medium rounded-lg bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
-                    >
-                      {copied ? 'Gekopieerd!' : 'Kopieer bedrag'}
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              {/* Breakdown */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Opbouw schatting</h2>
-                <div className="space-y-2 text-sm">
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Basiswaarde (m² x buurtprijs)</span>
-                    <span>{formatPrijs(addressResult.basis_waarde)}</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Energielabel correctie</span>
-                    <span
-                      className={
-                        addressResult.energielabel_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {addressResult.energielabel_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(addressResult.energielabel_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Bouwjaar correctie</span>
-                    <span
-                      className={
-                        addressResult.bouwjaar_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {addressResult.bouwjaar_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(addressResult.bouwjaar_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Woningtype correctie</span>
-                    <span
-                      className={
-                        addressResult.woningtype_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {addressResult.woningtype_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(addressResult.woningtype_correctie)}
-                    </span>
-                  </div>
-                  {addressResult.perceel_correctie !== 0 && (
-                    <div className="flex justify-between">
-                      <span className="text-gray-600">Perceelgrootte correctie</span>
-                      <span
-                        className={
-                          addressResult.perceel_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                        }
-                      >
-                        {addressResult.perceel_correctie >= 0 ? '+' : ''}
-                        {formatPrijs(addressResult.perceel_correctie)}
-                      </span>
-                    </div>
-                  )}
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Marktcorrectie (overbieden)</span>
-                    <span className="text-green-600">
-                      +{formatPrijs(addressResult.markt_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between pt-2 border-t font-semibold">
-                    <span>Totaal</span>
-                    <span>{formatPrijs(addressResult.waarde_midden)}</span>
-                  </div>
-                </div>
-              </div>
-
-              {/* Data sources footer */}
-              <DataBronnenFooter bronnen={addressResult.data_bronnen} />
-            </div>
-          )}
-
-          {/* Simple mode results */}
-          {simpleResult && mode === 'simple' && (
-            <div className="space-y-4">
-              {/* Main result */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Geschatte waarde</h2>
-                <div className="text-center">
-                  <div className="text-4xl font-bold text-primary-700">
-                    {formatPrijs(simpleResult.waarde_midden)}
-                  </div>
-                  <div className="text-gray-500 mt-1">
-                    {formatPrijs(simpleResult.waarde_laag)} - {formatPrijs(simpleResult.waarde_hoog)}
-                  </div>
-                </div>
-
-                <ConfidenceBar confidence={simpleResult.confidence} />
-
-                {simpleResult.vraagprijs && (
-                  <div className="mt-4 pt-4 border-t">
-                    <div className="flex justify-between items-center">
-                      <span className="text-gray-600">Vraagprijs</span>
-                      <span className="font-medium">{formatPrijs(simpleResult.vraagprijs)}</span>
-                    </div>
-                    {simpleResult.verschil_percentage !== null && simpleResult.verschil_percentage !== undefined && (
-                      <div className="flex justify-between items-center mt-1">
-                        <span className="text-gray-600">Verschil</span>
-                        <span
-                          className={
-                            simpleResult.verschil_percentage > 0
-                              ? 'text-red-600 font-medium'
-                              : 'text-green-600 font-medium'
-                          }
-                        >
-                          {simpleResult.verschil_percentage > 0 ? '+' : ''}
-                          {simpleResult.verschil_percentage.toFixed(1)}%
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Bid advice */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Biedadvies</h2>
-                <div className="flex items-center justify-between">
-                  <BiedAdviesBadge advies={simpleResult.bied_advies} />
-                </div>
-                <div className="mt-4 bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-600">Aanbevolen biedingsbereik</div>
-                  <div className="flex items-center justify-between">
-                    <div className="text-xl font-semibold">
-                      {formatPrijs(simpleResult.bied_range_laag)} - {formatPrijs(simpleResult.bied_range_hoog)}
-                    </div>
-                    <button
-                      onClick={() => handleCopy(simpleResult.waarde_midden)}
-                      className="px-3 py-1 text-sm font-medium rounded-lg bg-primary-100 text-primary-700 hover:bg-primary-200 transition-colors"
-                    >
-                      {copied ? 'Gekopieerd!' : 'Kopieer bedrag'}
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              {/* Breakdown */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h2 className="text-lg font-semibold mb-4">Opbouw schatting</h2>
-                <div className="space-y-2 text-sm">
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Basiswaarde (m² x buurtprijs)</span>
-                    <span>{formatPrijs(simpleResult.basis_waarde)}</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Energielabel correctie</span>
-                    <span
-                      className={
-                        simpleResult.energielabel_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {simpleResult.energielabel_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(simpleResult.energielabel_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Bouwjaar correctie</span>
-                    <span
-                      className={
-                        simpleResult.bouwjaar_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {simpleResult.bouwjaar_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(simpleResult.bouwjaar_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Woningtype correctie</span>
-                    <span
-                      className={
-                        simpleResult.woningtype_correctie >= 0 ? 'text-green-600' : 'text-red-600'
-                      }
-                    >
-                      {simpleResult.woningtype_correctie >= 0 ? '+' : ''}
-                      {formatPrijs(simpleResult.woningtype_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-gray-600">Marktcorrectie (overbieden)</span>
-                    <span className="text-green-600">
-                      +{formatPrijs(simpleResult.markt_correctie)}
-                    </span>
-                  </div>
-                  <div className="flex justify-between pt-2 border-t font-semibold">
-                    <span>Totaal</span>
-                    <span>{formatPrijs(simpleResult.waarde_midden)}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {!simpleResult && !addressResult && !isError && (
-            <div className="bg-gray-50 rounded-lg p-8 text-center text-gray-500">
-              {mode === 'address'
-                ? 'Vul het adres in om WOZ-waarde, energielabel en waardebepaling op te halen'
-                : 'Vul de woninggegevens in om een waardebepaling te krijgen'}
-            </div>
-          )}
+      {/* Resultaten in twee kolommen */}
+      {result && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-1">
+            <WoningGegevensColumn result={result} />
+          </div>
+          <div className="lg:col-span-2">
+            <AnalyseColumn result={result} onCopy={handleCopy} copied={copied} />
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Lege staat */}
+      {!result && !mutation.isError && !mutation.isPending && (
+        <div className="bg-gray-50 rounded-lg p-8 text-center text-gray-500">
+          Vul het adres in om WOZ-waarde, energielabel en waardebepaling op te halen
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -102,6 +102,10 @@ export interface EnhancedWaardebepalingResponse {
   woz_waarde?: number
   woz_peiljaar?: number
   grondoppervlakte?: number
+  // Woninggegevens (auto-fetched)
+  woonoppervlakte?: number
+  bouwjaar?: number
+  woningtype?: string
   // Energielabel (auto-fetched)
   energielabel?: string
   energielabel_bron: string


### PR DESCRIPTION
## Summary

- Verwijder handmatige invoermodus — alleen nog adres-lookup (postcode + huisnummer)
- Compact zoekformulier bovenaan de pagina met alle invoervelden op één rij
- Twee-kolom layout: woninggegevens (links, 1fr) en analyse & advies (rechts, 2fr)
- Backend retourneert nu ook `woonoppervlakte`, `bouwjaar` en `woningtype` in de enhanced response
- Responsive: kolommen gestapeld op mobiel

## Test plan

- [ ] Zoek op postcode + huisnummer → linkerkolom toont woninggegevens, rechterkolom toont analyse
- [ ] Controleer dat handmatige invoermodus niet meer zichtbaar is
- [ ] Test mobiel: kolommen gestapeld
- [ ] TypeScript: `npx tsc --noEmit` geen fouten

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)