### PR TITLE
feat: buurtdata uitbreiding, vergelijker & waardebepaling

### DIFF
--- a/backend/api/buurten.py
+++ b/backend/api/buurten.py
@@ -8,8 +8,19 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from models import get_db, Buurt
+from services.scoring import ScoringService
 
 router = APIRouter(prefix="/api/buurten", tags=["buurten"])
+
+# Singleton scoring service for metadata
+_scoring_service = None
+
+
+def _get_scoring_service() -> ScoringService:
+    global _scoring_service
+    if _scoring_service is None:
+        _scoring_service = ScoringService()
+    return _scoring_service
 
 
 class BuurtBase(BaseModel):
@@ -42,26 +53,79 @@ class BuurtDetail(BuurtBase):
     score_veiligheid: Optional[float] = None
     score_voorzieningen: Optional[float] = None
     score_woningen: Optional[float] = None
+    score_bereikbaarheid: Optional[float] = None
+    score_leefbaarheid: Optional[float] = None
     score_coverage: Optional[float] = None
 
     leefbaarometer_score: Optional[float] = None
+    leefbaarometer_fysiek: Optional[float] = None
+    leefbaarometer_voorzieningen: Optional[float] = None
+    leefbaarometer_veiligheid: Optional[float] = None
+    leefbaarometer_bevolking: Optional[float] = None
+    leefbaarometer_woningen: Optional[float] = None
+
     median_vraagprijs: Optional[int] = None
     median_m2_prijs: Optional[float] = None
     aantal_te_koop: Optional[int] = None
+
+    indicatoren: Optional[Dict[str, Any]] = None
 
     class Config:
         from_attributes = True
 
 
+class IndicatorMeta(BaseModel):
+    """Metadata for a single indicator."""
+    label: str
+    category: Optional[str] = None
+    unit: str = ""
+    higher_is_better: bool = True
+    weight: float = 0.0
+    description: str = ""
+
+
+class CategoryMeta(BaseModel):
+    """Metadata for a category."""
+    label: str
+    color: str = "#6b7280"
+    weight: float = 0.0
+    indicators: List[str] = []
+
+
+class IndicatorMetaResponse(BaseModel):
+    """Response for indicator metadata endpoint."""
+    indicators: Dict[str, IndicatorMeta]
+    categories: Dict[str, CategoryMeta]
+
+
 class BuurtVergelijk(BaseModel):
     """Schema for neighborhood comparison."""
     buurten: List[BuurtDetail]
+    categories: Dict[str, CategoryMeta] = {}
+
+
+@router.get("/indicatoren/meta", response_model=IndicatorMetaResponse)
+def get_indicator_meta():
+    """Get metadata for all available indicators and categories."""
+    scorer = _get_scoring_service()
+    ind_meta = scorer.get_indicator_meta()
+    cat_meta = scorer.get_category_meta()
+
+    return IndicatorMetaResponse(
+        indicators={
+            k: IndicatorMeta(**v) for k, v in ind_meta.items()
+        },
+        categories={
+            k: CategoryMeta(**v) for k, v in cat_meta.items()
+        },
+    )
 
 
 @router.get("/geojson")
 def get_buurten_geojson(
     gemeente: Optional[str] = Query(None, description="Filter by municipality"),
     min_score: Optional[float] = Query(None, ge=0, le=1, description="Minimum score"),
+    indicator: Optional[str] = Query(None, description="Indicator to include in properties"),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Get buurt boundaries as GeoJSON FeatureCollection."""
@@ -81,17 +145,37 @@ def get_buurten_geojson(
         if isinstance(geometry, str):
             geometry = json.loads(geometry)
 
+        properties = {
+            "code": buurt.code,
+            "naam": buurt.naam,
+            "gemeente_naam": buurt.gemeente_naam,
+            "score_totaal": buurt.score_totaal,
+            "median_vraagprijs": buurt.median_vraagprijs,
+            "aantal_te_koop": buurt.aantal_te_koop,
+            # Category scores for tooltip
+            "score_inkomen": buurt.score_inkomen,
+            "score_veiligheid": buurt.score_veiligheid,
+            "score_voorzieningen": buurt.score_voorzieningen,
+            "score_woningen": buurt.score_woningen,
+        }
+
+        # Add specific indicator value if requested
+        if indicator:
+            indicator_value = None
+            # Check model columns first
+            if hasattr(buurt, indicator):
+                indicator_value = getattr(buurt, indicator)
+            # Then check indicatoren JSON
+            elif buurt.indicatoren and indicator in buurt.indicatoren:
+                indicator_value = buurt.indicatoren[indicator]
+
+            properties["indicator_value"] = indicator_value
+            properties["indicator_key"] = indicator
+
         features.append({
             "type": "Feature",
             "geometry": geometry,
-            "properties": {
-                "code": buurt.code,
-                "naam": buurt.naam,
-                "gemeente_naam": buurt.gemeente_naam,
-                "score_totaal": buurt.score_totaal,
-                "median_vraagprijs": buurt.median_vraagprijs,
-                "aantal_te_koop": buurt.aantal_te_koop,
-            },
+            "properties": properties,
         })
 
     return {
@@ -126,6 +210,38 @@ def list_buurten(
         query = query.order_by(Buurt.median_vraagprijs.asc().nullslast())
 
     return query.limit(limit).all()
+
+
+@router.get("/vergelijk/", response_model=BuurtVergelijk)
+def vergelijk_buurten(
+    codes: List[str] = Query(..., description="Buurt codes to compare", max_length=5),
+    db: Session = Depends(get_db),
+):
+    """Compare up to 5 neighborhoods side by side."""
+    if len(codes) > 5:
+        raise HTTPException(
+            status_code=400,
+            detail="Maximaal 5 buurten kunnen worden vergeleken"
+        )
+
+    codes_upper = [c.upper() for c in codes]
+    buurten = db.query(Buurt).filter(Buurt.code.in_(codes_upper)).all()
+
+    if len(buurten) != len(codes):
+        found = {b.code for b in buurten}
+        missing = set(codes_upper) - found
+        raise HTTPException(
+            status_code=404,
+            detail=f"Buurten niet gevonden: {', '.join(missing)}"
+        )
+
+    scorer = _get_scoring_service()
+    cat_meta = scorer.get_category_meta()
+
+    return BuurtVergelijk(
+        buurten=[BuurtDetail.model_validate(b) for b in buurten],
+        categories={k: CategoryMeta(**v) for k, v in cat_meta.items()},
+    )
 
 
 @router.get("/{code}", response_model=BuurtDetail)
@@ -164,29 +280,3 @@ def get_buurt_woningen(
         "woningen": woningen,
         "count": len(woningen),
     }
-
-
-@router.get("/vergelijk/", response_model=BuurtVergelijk)
-def vergelijk_buurten(
-    codes: List[str] = Query(..., description="Buurt codes to compare", max_length=5),
-    db: Session = Depends(get_db),
-):
-    """Compare up to 5 neighborhoods side by side."""
-    if len(codes) > 5:
-        raise HTTPException(
-            status_code=400,
-            detail="Maximaal 5 buurten kunnen worden vergeleken"
-        )
-
-    codes_upper = [c.upper() for c in codes]
-    buurten = db.query(Buurt).filter(Buurt.code.in_(codes_upper)).all()
-
-    if len(buurten) != len(codes):
-        found = {b.code for b in buurten}
-        missing = set(codes_upper) - found
-        raise HTTPException(
-            status_code=404,
-            detail=f"Buurten niet gevonden: {', '.join(missing)}"
-        )
-
-    return BuurtVergelijk(buurten=[BuurtDetail.model_validate(b) for b in buurten])

--- a/backend/api/woningen.py
+++ b/backend/api/woningen.py
@@ -100,6 +100,7 @@ class WaardebepalingResponse(BaseModel):
     bouwjaar_correctie: int
     woningtype_correctie: int
     perceel_correctie: int = 0
+    buurt_kwaliteit_correctie: int = 0
     markt_correctie: int
 
     confidence: float
@@ -236,6 +237,7 @@ class EnhancedWaardebepalingResponse(BaseModel):
     bouwjaar_correctie: int
     woningtype_correctie: int
     perceel_correctie: int = 0
+    buurt_kwaliteit_correctie: int = 0
     markt_correctie: int
 
     confidence: float
@@ -426,6 +428,7 @@ def get_woning_waarde(woning_id: int, db: Session = Depends(get_db)):
         bouwjaar_correctie=result.bouwjaar_correctie,
         woningtype_correctie=result.woningtype_correctie,
         perceel_correctie=result.perceel_correctie,
+        buurt_kwaliteit_correctie=result.buurt_kwaliteit_correctie,
         markt_correctie=result.markt_correctie,
         confidence=result.confidence,
         confidence_factors=result.confidence_factors,
@@ -459,6 +462,7 @@ def bereken_waarde(request: WaardebepalingRequest, db: Session = Depends(get_db)
         bouwjaar_correctie=result.bouwjaar_correctie,
         woningtype_correctie=result.woningtype_correctie,
         perceel_correctie=result.perceel_correctie,
+        buurt_kwaliteit_correctie=result.buurt_kwaliteit_correctie,
         markt_correctie=result.markt_correctie,
         confidence=result.confidence,
         confidence_factors=result.confidence_factors,
@@ -998,6 +1002,7 @@ def bereken_waarde_voor_adres(
         bouwjaar_correctie=valuation.bouwjaar_correctie,
         woningtype_correctie=valuation.woningtype_correctie,
         perceel_correctie=valuation.perceel_correctie,
+        buurt_kwaliteit_correctie=valuation.buurt_kwaliteit_correctie,
         markt_correctie=valuation.markt_correctie,
         confidence=valuation.confidence,
         confidence_factors=valuation.confidence_factors,

--- a/backend/bulk_buurt_data.py
+++ b/backend/bulk_buurt_data.py
@@ -1,0 +1,289 @@
+"""
+Bulk download and scoring of neighborhood data.
+
+Fetches data from all collectors (CBS Kerncijfers, Leefbaarometer, CBS Nabijheid, RIVM),
+merges into a single dataset, calculates scores, and writes to the database.
+
+Usage:
+    cd backend && source venv/bin/activate
+    python bulk_buurt_data.py [--skip-rivm] [--clear-cache]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import text
+
+# Ensure backend is on path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from models.database import SessionLocal, init_db
+from models.buurt import Buurt
+from collectors.cbs_buurt_collector import CBSBuurtCollector, HOUSING_COLUMNS
+from collectors.leefbaarometer_collector import create_leefbaarometer_collector
+from collectors.cbs_nabijheid_collector import create_cbs_nabijheid_collector
+from collectors.rivm_collector import create_rivm_collector
+from services.scoring import ScoringService
+
+
+def fetch_all_data(skip_rivm: bool = False):
+    """Fetch data from all collectors and merge."""
+    print("=== CBS Kerncijfers laden ===")
+    cbs = CBSBuurtCollector()
+    buurten = cbs.get_all_buurten()
+    print(f"  {len(buurten)} buurten geladen")
+
+    print("\n=== Leefbaarometer laden ===")
+    try:
+        lbm = create_leefbaarometer_collector()
+        lbm_data = lbm.get_all()
+        print(f"  {len(lbm_data)} buurten met Leefbaarometer data")
+    except Exception as e:
+        print(f"  Leefbaarometer laden mislukt: {e}")
+        lbm_data = {}
+
+    print("\n=== CBS Nabijheid laden ===")
+    try:
+        nabijheid = create_cbs_nabijheid_collector()
+        nabijheid_data = nabijheid.get_all()
+        print(f"  {len(nabijheid_data)} buurten met nabijheiddata")
+    except Exception as e:
+        print(f"  CBS Nabijheid laden mislukt: {e}")
+        nabijheid_data = {}
+
+    rivm_data = {}
+    if not skip_rivm:
+        print("\n=== RIVM Atlas laden ===")
+        try:
+            rivm = create_rivm_collector()
+            # RIVM requires centroids - we'll calculate from existing geometrie
+            # For now, load from cache if available
+            rivm_data = rivm.get_all()
+            print(f"  {len(rivm_data)} buurten met RIVM data (uit cache)")
+            if not rivm_data:
+                print("  Geen RIVM data in cache. Gebruik bulk_buurt_data.py --fetch-rivm om te downloaden.")
+        except Exception as e:
+            print(f"  RIVM laden mislukt: {e}")
+    else:
+        print("\n=== RIVM overgeslagen (--skip-rivm) ===")
+
+    return buurten, lbm_data, nabijheid_data, rivm_data
+
+
+def merge_and_score(buurten, lbm_data, nabijheid_data, rivm_data):
+    """Merge all data sources and calculate scores."""
+    print("\n=== Data samenvoegen ===")
+
+    records = []
+    for buurt in buurten:
+        record = {
+            "buurt_code": buurt.buurt_code,
+            "buurt_naam": buurt.buurt_naam,
+            "gemeente_code": buurt.gemeente_code,
+            "gemeente_naam": buurt.gemeente_naam,
+            "gem_woz_waarde": buurt.gem_woz_waarde,
+            "koopwoningen_pct": buurt.koopwoningen_pct,
+            "huurwoningen_pct": buurt.huurwoningen_pct,
+            "gem_inkomen": buurt.gem_inkomen,
+            "huishoudens_laag_inkomen_pct": buurt.huishoudens_laag_inkomen_pct,
+        }
+
+        # Merge CBS extended indicators
+        indicatoren = dict(buurt.indicatoren) if buurt.indicatoren else {}
+
+        # Merge Leefbaarometer
+        lbm = lbm_data.get(buurt.buurt_code)
+        if lbm:
+            record["lbm"] = lbm.lbm_score
+            record["leefbaarometer_fysiek"] = lbm.fysieke_omgeving
+            record["leefbaarometer_voorzieningen"] = lbm.voorzieningen
+            record["leefbaarometer_veiligheid"] = lbm.veiligheid
+            record["leefbaarometer_bevolking"] = lbm.bevolkingssamenstelling
+            record["leefbaarometer_woningen"] = lbm.woningvoorraad
+            # Also add to indicatoren
+            indicatoren["leefbaarometer_veiligheid"] = lbm.veiligheid
+            indicatoren["leefbaarometer_fysiek"] = lbm.fysieke_omgeving
+
+        # Merge Nabijheid
+        nab = nabijheid_data.get(buurt.buurt_code)
+        if nab:
+            for key, val in nab.afstanden.items():
+                indicatoren[key] = val
+
+        # Merge RIVM
+        rivm = rivm_data.get(buurt.buurt_code)
+        if rivm:
+            if rivm.no2_concentratie is not None:
+                indicatoren["no2_concentratie"] = rivm.no2_concentratie
+            if rivm.pm25_concentratie is not None:
+                indicatoren["pm25_concentratie"] = rivm.pm25_concentratie
+            if rivm.pm10_concentratie is not None:
+                indicatoren["pm10_concentratie"] = rivm.pm10_concentratie
+            if rivm.geluid_weg_lden is not None:
+                indicatoren["geluid_weg_lden"] = rivm.geluid_weg_lden
+
+        record["indicatoren"] = indicatoren
+
+        # Add indicator values as flat columns for scoring
+        for key, val in indicatoren.items():
+            if val is not None:
+                record[key] = val
+
+        records.append(record)
+
+    df = pd.DataFrame(records)
+    print(f"  {len(df)} buurten, {len(df.columns)} kolommen")
+
+    # Calculate scores
+    print("\n=== Scores berekenen ===")
+    scorer = ScoringService()
+    scored = scorer.calculate_scores(df)
+
+    # Show score distribution
+    if "score" in scored.columns:
+        valid_scores = scored["score"].dropna()
+        if len(valid_scores) > 0:
+            print(f"  Score range: {valid_scores.min():.2f} - {valid_scores.max():.2f}")
+            print(f"  Score gemiddelde: {valid_scores.mean():.2f}")
+            print(f"  Buurten met score: {len(valid_scores)}/{len(scored)}")
+
+    # Show category scores
+    for cat_id in scorer.categories:
+        col = f"score_{cat_id}"
+        if col in scored.columns:
+            valid = scored[col].dropna()
+            if len(valid) > 0:
+                print(f"  {cat_id}: {valid.mean():.2f} avg ({len(valid)} buurten)")
+
+    return scored
+
+
+def write_to_database(scored_df: pd.DataFrame):
+    """Write scored buurt data to database."""
+    print("\n=== Database schrijven ===")
+
+    init_db()
+    session = SessionLocal()
+
+    try:
+        # Drop and recreate buurten data (all data is re-downloadable)
+        existing = session.query(Buurt).count()
+        print(f"  Bestaande buurten: {existing}")
+
+        updated = 0
+        created = 0
+
+        for _, row in scored_df.iterrows():
+            code = row.get("buurt_code", "")
+            if not code:
+                continue
+
+            buurt = session.query(Buurt).filter(Buurt.code == code).first()
+            if not buurt:
+                buurt = Buurt(code=code)
+                session.add(buurt)
+                created += 1
+            else:
+                updated += 1
+
+            buurt.naam = row.get("buurt_naam", "")
+            buurt.gemeente_code = row.get("gemeente_code", "")
+            buurt.gemeente_naam = row.get("gemeente_naam", "")
+
+            # CBS core fields
+            ind = row.get("indicatoren", {})
+            buurt.inwoners = _safe_int(ind.get("inwoners"))
+            buurt.huishoudens = _safe_int(ind.get("huishoudens_totaal"))
+            buurt.gemiddeld_inkomen = row.get("gem_inkomen")
+            buurt.woz_waarde = row.get("gem_woz_waarde")
+            buurt.gasverbruik = _safe_float(ind.get("gem_gasverbruik"))
+            buurt.elektraverbruik = _safe_float(ind.get("gem_elektraverbruik"))
+            buurt.arbeidsparticipatie = _safe_float(ind.get("arbeidsparticipatie"))
+
+            # Extended indicators (JSON)
+            buurt.indicatoren = ind if ind else None
+
+            # Scores
+            buurt.score_totaal = _safe_float(row.get("score"))
+            buurt.score_coverage = _safe_float(row.get("score_coverage"))
+            buurt.score_inkomen = _safe_float(row.get("score_inkomen"))
+            buurt.score_veiligheid = _safe_float(row.get("score_veiligheid"))
+            buurt.score_voorzieningen = _safe_float(row.get("score_voorzieningen"))
+            buurt.score_woningen = _safe_float(row.get("score_woningen"))
+            buurt.score_bereikbaarheid = _safe_float(row.get("score_bereikbaarheid"))
+            buurt.score_leefbaarheid = _safe_float(row.get("score_leefbaarheid"))
+            buurt.score_energie = _safe_float(row.get("score_energie"))
+            buurt.score_demografie = _safe_float(row.get("score_demografie"))
+
+            # Leefbaarometer
+            buurt.leefbaarometer_score = _safe_float(row.get("lbm"))
+            buurt.leefbaarometer_fysiek = _safe_float(row.get("leefbaarometer_fysiek"))
+            buurt.leefbaarometer_voorzieningen = _safe_float(row.get("leefbaarometer_voorzieningen"))
+            buurt.leefbaarometer_veiligheid = _safe_float(row.get("leefbaarometer_veiligheid"))
+            buurt.leefbaarometer_bevolking = _safe_float(row.get("leefbaarometer_bevolking"))
+            buurt.leefbaarometer_woningen = _safe_float(row.get("leefbaarometer_woningen"))
+
+            buurt.data_jaar = 2024
+
+        session.commit()
+        print(f"  {created} aangemaakt, {updated} bijgewerkt")
+
+    except Exception as e:
+        session.rollback()
+        print(f"  FOUT: {e}")
+        raise
+    finally:
+        session.close()
+
+
+def _safe_float(val) -> float | None:
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_int(val) -> int | None:
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return None
+    try:
+        return int(float(val))
+    except (ValueError, TypeError):
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bulk download buurtdata")
+    parser.add_argument("--skip-rivm", action="store_true", help="Skip RIVM Atlas data")
+    parser.add_argument("--clear-cache", action="store_true", help="Clear cache first")
+    args = parser.parse_args()
+
+    if args.clear_cache:
+        import shutil
+        cache_dirs = [
+            Path(__file__).parent.parent / "data" / "cache" / d
+            for d in ["leefbaarometer", "cbs_nabijheid", "rivm"]
+        ]
+        for d in cache_dirs:
+            if d.exists():
+                shutil.rmtree(d)
+                print(f"Cache verwijderd: {d}")
+
+    buurten, lbm_data, nabijheid_data, rivm_data = fetch_all_data(
+        skip_rivm=args.skip_rivm
+    )
+    scored = merge_and_score(buurten, lbm_data, nabijheid_data, rivm_data)
+    write_to_database(scored)
+
+    print("\n=== Klaar! ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -13,6 +13,21 @@ from collectors.cbs_buurt_collector import (
     create_cbs_buurt_collector,
     lookup_buurt_code_pdok,
 )
+from collectors.cbs_nabijheid_collector import (
+    CBSNabijheidCollector,
+    NabijheidResult,
+    create_cbs_nabijheid_collector,
+)
+from collectors.leefbaarometer_collector import (
+    LeefbaarometerCollector,
+    LeefbaarometerResult,
+    create_leefbaarometer_collector,
+)
+from collectors.rivm_collector import (
+    RIVMCollector,
+    RIVMResult,
+    create_rivm_collector,
+)
 from collectors.woz_collector import WOZCollector, WOZResult, create_woz_collector
 from collectors.energielabel_collector import (
     EnergielabelCollector,
@@ -48,6 +63,18 @@ __all__ = [
     "BuurtData",
     "create_cbs_buurt_collector",
     "lookup_buurt_code_pdok",
+    # CBS Nabijheid
+    "CBSNabijheidCollector",
+    "NabijheidResult",
+    "create_cbs_nabijheid_collector",
+    # Leefbaarometer
+    "LeefbaarometerCollector",
+    "LeefbaarometerResult",
+    "create_leefbaarometer_collector",
+    # RIVM
+    "RIVMCollector",
+    "RIVMResult",
+    "create_rivm_collector",
     # WOZ
     "WOZCollector",
     "WOZResult",

--- a/backend/collectors/cbs_buurt_collector.py
+++ b/backend/collectors/cbs_buurt_collector.py
@@ -2,13 +2,8 @@
 CBS Buurt (Neighborhood) Data Collector.
 
 Fetches neighborhood-level statistics from CBS "Kerncijfers wijken en buurten" (85618NED).
-Provides housing indicators at buurt level for more accurate valuations.
-
-Key indicators:
-- Gemiddelde WOZ-waarde: Average property valuation per neighborhood
-- Koopwoningen: Percentage owner-occupied homes
-- Bouwjaar: Building age distribution
-- Inkomen: Average income per resident
+Extended to ~50 indicators across categories: bevolking, woningen, inkomen, energie,
+voorzieningen, motorvoertuigen.
 """
 
 from __future__ import annotations
@@ -33,15 +28,78 @@ CACHE_DURATION_SECONDS = 30 * 24 * 60 * 60  # 30 days (yearly dataset)
 # Target municipalities
 TARGET_MUNICIPALITIES = ["0518", "1916", "0603"]  # Den Haag, Leidschendam-Voorburg, Rijswijk
 
-# CBS column names for housing indicators
+# CBS column names for housing indicators - extended to ~50
+# Organized by category for clarity
 HOUSING_COLUMNS = {
+    # === Bevolking ===
+    "inwoners": "AantalInwoners_5",
+    "mannen": "Mannen_6",
+    "vrouwen": "Vrouwen_7",
+    "leeftijd_0_14": "k_0Tot15Jaar_8",
+    "leeftijd_15_24": "k_15Tot25Jaar_9",
+    "leeftijd_25_44": "k_25Tot45Jaar_10",
+    "leeftijd_45_64": "k_45Tot65Jaar_11",
+    "leeftijd_65_plus": "k_65JaarOfOuder_12",
+    "ongehuwd": "Ongehuwd_13",
+    "gehuwd": "Gehuwd_14",
+    "gescheiden": "Gescheiden_15",
+    "verweduwd": "Verweduwd_16",
+    "bevolkingsdichtheid": "Bevolkingsdichtheid_33",
+    "huishoudens_totaal": "HuishoudensTotaal_28",
+    "eenpersoons_huishoudens": "Eenpersoonshuishoudens_29",
+    "huishoudens_zonder_kinderen": "HuishoudensZonderKinderen_30",
+    "huishoudens_met_kinderen": "HuishoudensMetKinderen_31",
+    "gem_huishoudensgrootte": "GemiddeldeHuishoudensgrootte_32",
+
+    # === Woningen ===
+    "woningvoorraad": "Woningvoorraad_34",
     "woz_waarde": "GemiddeldeWOZWaardeVanWoningen_35",
     "koopwoningen_pct": "Koopwoningen_40",
     "huurwoningen_pct": "HuurwoningenTotaal_41",
+    "huur_corporatie_pct": "InBezitWoningcorporatie_42",
+    "huur_overig_pct": "InBezitOverigeVerhuurders_43",
+    "eigendom_onbekend_pct": "EigendomOnbekend_44",
     "bouwjaar_voor_2000_pct": "BouwjaarVoor2000_53",
     "bouwjaar_vanaf_2000_pct": "BouwjaarVanaf2000_54",
+
+    # === Energie ===
+    "gem_gasverbruik": "GemiddeldAardgasverbruikTotaal_27",
+    "gem_elektraverbruik": "GemiddeldeElektriciteitsleveringTotaal_23",
+
+    # === Inkomen ===
     "gem_inkomen": "GemiddeldInkomenPerInwoner_66",
+    "gem_inkomen_ontvanger": "GemiddeldInkomenPerInkomensontvwordt_67",
     "huishoudens_laag_inkomen_pct": "HuishoudensMetEenLaagInkomen_70",
+    "huishoudens_hoog_inkomen_pct": "HuishoudensMetEenHoogInkomen_71",
+    "huishoudens_onder_of_rond_sociaal_minimum": "HuishOnderOfRondSociaalMinimum_72",
+
+    # === Uitkeringen ===
+    "bijstandsuitkeringen_per_1000": "PersonenPerSoortUitkBijwordt_75",
+    "ao_uitkeringen_per_1000": "PersonenPerSoortUitkAO_76",
+    "ww_uitkeringen_per_1000": "PersonenPerSoortUitkWW_77",
+    "aow_uitkeringen_per_1000": "PersonenPerSoortUitkAOW_78",
+
+    # === Motorvoertuigen ===
+    "personenautos_totaal": "PersonenautoSTotaal_109",
+    "personenautos_per_huishouden": "PersonenautoSPerHuishouden_110",
+    "personenautos_brandstof_benzine": "Personenautos_111",  # benzine
+    "personenautos_brandstof_overig": "PersonenautoSOverigeBrandstof_112",
+
+    # === Voorzieningen (afstanden in km) ===
+    "afstand_huisartsenpraktijk": "AfstandTotHuisartsenpraktijk_100",
+    "afstand_ziekenhuis": "AfstandTotZiekenhuis_102",
+    "afstand_basisonderwijs": "AfstandTotSchoolBasisonderwijs_97",
+    "afstand_voortgezet_onderwijs": "AfstandTotSchoolVoortgezetOndwordt_98",
+    "afstand_kinderdagverblijf": "AfstandTotKinderdagverblijf_96",
+    "afstand_grote_supermarkt": "AfstandTotGroteSupermarkt_92",
+    "afstand_cafe": "AfstandTotCafe_89",
+    "afstand_restaurant": "AfstandTotRestaurant_95",
+    "afstand_bioscoop": "AfstandTotBioscoop_87",
+    "afstand_zwembad": "AfstandTotZwembad_106",
+    "afstand_sportterrein": "AfstandTotSportterrein_105",
+    "afstand_bibliotheek": "AfstandTotBibliotheek_86",
+    "afstand_oprit_hoofdverkeersweg": "AfstandTotOpritHoofdverkeersweg_93",
+    "afstand_treinstation": "AfstandTotBelangrijkOverstapstation_88",
 }
 
 
@@ -68,6 +126,9 @@ class BuurtData:
     # Income indicators
     gem_inkomen: Optional[int] = None  # x 1000 euro
     huishoudens_laag_inkomen_pct: Optional[float] = None
+
+    # Extended indicators (all CBS data beyond core fields)
+    indicatoren: Dict[str, Any] = field(default_factory=dict)
 
     bron: str = "CBS Kerncijfers wijken en buurten"
 
@@ -135,6 +196,7 @@ class CBSBuurtCollector:
                     "bouwjaar_vanaf_2000_pct": b.bouwjaar_vanaf_2000_pct,
                     "gem_inkomen": b.gem_inkomen,
                     "huishoudens_laag_inkomen_pct": b.huishoudens_laag_inkomen_pct,
+                    "indicatoren": b.indicatoren,
                     "bron": b.bron,
                 }
                 for code, b in self._buurt_data.items()
@@ -215,6 +277,22 @@ class CBSBuurtCollector:
                 except (ValueError, TypeError):
                     pass
 
+            # Parse all extended indicators
+            indicatoren = {}
+            for indicator_key, cbs_column in HOUSING_COLUMNS.items():
+                # Skip core fields already handled above
+                if indicator_key in ("woz_waarde", "gem_inkomen", "koopwoningen_pct",
+                                     "huurwoningen_pct", "bouwjaar_voor_2000_pct",
+                                     "bouwjaar_vanaf_2000_pct", "huishoudens_laag_inkomen_pct"):
+                    continue
+
+                raw_val = record.get(cbs_column)
+                if raw_val is not None:
+                    try:
+                        indicatoren[indicator_key] = float(raw_val)
+                    except (ValueError, TypeError):
+                        pass
+
             buurt = BuurtData(
                 buurt_code=buurt_code,
                 buurt_naam=str(record.get("WijkenEnBuurten", "")).strip(),
@@ -227,6 +305,7 @@ class CBSBuurtCollector:
                 bouwjaar_vanaf_2000_pct=parse_pct("bouwjaar_vanaf_2000_pct"),
                 gem_inkomen=gem_inkomen,
                 huishoudens_laag_inkomen_pct=parse_pct("huishoudens_laag_inkomen_pct"),
+                indicatoren=indicatoren,
             )
 
             self._buurt_data[buurt_code] = buurt

--- a/backend/collectors/cbs_nabijheid_collector.py
+++ b/backend/collectors/cbs_nabijheid_collector.py
@@ -1,0 +1,187 @@
+"""
+CBS Nabijheid Voorzieningen Collector.
+
+Fetches detailed proximity data from CBS dataset 80306ned
+"Nabijheid voorzieningen; afstand locatie, wijk- en buurtcijfers".
+Provides more detailed distance data than Kerncijfers.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+CBS_API_BASE = "https://opendata.cbs.nl/ODataApi/odata"
+DATASET_NABIJHEID = "80306ned"
+
+CACHE_DIR = Path(__file__).parent.parent.parent / "data" / "cache" / "cbs_nabijheid"
+CACHE_DURATION_SECONDS = 30 * 24 * 60 * 60  # 30 days
+
+TARGET_MUNICIPALITIES = ["0518", "1916", "0603"]
+
+# Nabijheid columns - distances to various facilities
+NABIJHEID_COLUMNS = {
+    "afstand_huisarts": "AfstandTotHuisartsenpraktijk_1",
+    "afstand_apotheek": "AfstandTotApotheek_2",
+    "afstand_ziekenhuis_excl_buitenpoli": "AfstandTotZiekenhuisExclBuitenpoli_3",
+    "afstand_ziekenhuis_incl_buitenpoli": "AfstandTotZiekenhuisInclBuitenpoli_4",
+    "afstand_kinderdagverblijf": "AfstandTotKinderdagverblijf_5",
+    "afstand_buitenschoolse_opvang": "AfstandTotBuitenschoolseOpvang_6",
+    "afstand_basisonderwijs": "AfstandTotBasisschool_7",
+    "afstand_vmbo": "AfstandTotLocatieVmbo_8",
+    "afstand_havo_vwo": "AfstandTotLocatieHavoVwo_9",
+    "afstand_supermarkt": "AfstandTotSupermarkt_10",
+    "afstand_warenhuis": "AfstandTotWarenhuis_11",
+    "afstand_cafe": "AfstandTotCafe_14",
+    "afstand_restaurant": "AfstandTotRestaurant_16",
+    "afstand_hotel": "AfstandTotHotel_17",
+    "afstand_bioscoop": "AfstandTotBioscoop_19",
+    "afstand_bibliotheek": "AfstandTotBibliotheek_21",
+    "afstand_zwembad": "AfstandTotZwembad_22",
+    "afstand_sporthal": "AfstandTotSporthal_24",
+    "afstand_museum": "AfstandTotMuseum_26",
+    "afstand_attractiepark": "AfstandTotAttractiepark_28",
+    "afstand_brandweerkazerne": "AfstandTotBrandweerkazerne_29",
+    "afstand_oprit_hoofdverkeersweg": "AfstandTotOpritHoofdverkeersweg_30",
+    "afstand_treinstation": "AfstandTotTreinstation_31",
+}
+
+
+@dataclass
+class NabijheidResult:
+    """Proximity data for a neighborhood."""
+    buurt_code: str
+    afstanden: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"buurt_code": self.buurt_code, "afstanden": self.afstanden}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "NabijheidResult":
+        return cls(buurt_code=data["buurt_code"], afstanden=data.get("afstanden", {}))
+
+
+@dataclass
+class CBSNabijheidCollector:
+    """Collector for CBS Nabijheid voorzieningen data."""
+
+    cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
+    _data: Dict[str, NabijheidResult] = field(default_factory=dict, init=False, repr=False)
+    _loaded: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache_path(self) -> Path:
+        return self.cache_dir / "cbs_nabijheid_data.json"
+
+    def _load_from_cache(self) -> bool:
+        cache_path = self._cache_path()
+        if not cache_path.exists():
+            return False
+        try:
+            with cache_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if data.get("timestamp", 0) + CACHE_DURATION_SECONDS < time.time():
+                return False
+            for code, entry in data.get("buurten", {}).items():
+                self._data[code] = NabijheidResult.from_dict(entry)
+            self._loaded = True
+            return True
+        except (json.JSONDecodeError, IOError, TypeError):
+            return False
+
+    def _save_to_cache(self) -> None:
+        cache_data = {
+            "timestamp": time.time(),
+            "buurten": {code: r.to_dict() for code, r in self._data.items()},
+        }
+        try:
+            with self._cache_path().open("w", encoding="utf-8") as f:
+                json.dump(cache_data, f, ensure_ascii=False)
+        except IOError:
+            pass
+
+    def _fetch_from_cbs(self) -> None:
+        """Fetch nabijheid data from CBS OData API."""
+        code_filters = []
+        for muni_code in TARGET_MUNICIPALITIES:
+            code_filters.append(f"startswith(Codering_3,'BU{muni_code}')")
+
+        params = {
+            "$filter": " or ".join(code_filters),
+        }
+
+        base_url = f"{CBS_API_BASE}/{DATASET_NABIJHEID}/TypedDataSet"
+        records = []
+        url = base_url
+        first_request = True
+
+        while url:
+            try:
+                if first_request:
+                    response = requests.get(url, params=params, timeout=120)
+                    first_request = False
+                else:
+                    response = requests.get(url, timeout=120)
+                response.raise_for_status()
+                data = response.json()
+            except requests.RequestException as exc:
+                raise RuntimeError(f"Failed to fetch CBS nabijheid data: {exc}") from exc
+
+            records.extend(data.get("value", []))
+            url = data.get("odata.nextLink") or data.get("@odata.nextLink")
+
+        for record in records:
+            buurt_code = str(record.get("Codering_3", "")).strip()
+            if not buurt_code.startswith("BU"):
+                continue
+
+            afstanden = {}
+            for key, cbs_col in NABIJHEID_COLUMNS.items():
+                raw = record.get(cbs_col)
+                if raw is not None:
+                    try:
+                        afstanden[key] = float(raw)
+                    except (ValueError, TypeError):
+                        pass
+
+            self._data[buurt_code] = NabijheidResult(
+                buurt_code=buurt_code,
+                afstanden=afstanden,
+            )
+
+        self._loaded = True
+        self._save_to_cache()
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if not self._load_from_cache():
+            self._fetch_from_cbs()
+
+    def get_buurt(self, buurt_code: str) -> Optional[NabijheidResult]:
+        """Get nabijheid data for a buurt."""
+        self._ensure_loaded()
+        code = buurt_code.upper().strip()
+        if not code.startswith("BU"):
+            code = f"BU{code}"
+        return self._data.get(code)
+
+    def get_all(self) -> Dict[str, NabijheidResult]:
+        """Get all nabijheid data."""
+        self._ensure_loaded()
+        return dict(self._data)
+
+
+def create_cbs_nabijheid_collector(cache_dir: Optional[Path] = None) -> CBSNabijheidCollector:
+    """Factory function with default cache directory."""
+    if cache_dir is None:
+        cache_dir = Path(__file__).parent.parent.parent / "data" / "cache" / "cbs_nabijheid"
+    return CBSNabijheidCollector(cache_dir=cache_dir)

--- a/backend/collectors/leefbaarometer_collector.py
+++ b/backend/collectors/leefbaarometer_collector.py
@@ -1,0 +1,188 @@
+"""
+Leefbaarometer 3.0 Collector.
+
+Fetches neighborhood livability scores from the Leefbaarometer dataset.
+Uses the Leefbaarometer 3.0 API (data.overheid.nl / PDOK WFS).
+
+The Leefbaarometer provides a composite score and 5 dimension scores:
+- Fysieke omgeving (physical environment)
+- Voorzieningen (facilities)
+- Veiligheid (safety)
+- Bevolkingssamenstelling (population composition)
+- Woningvoorraad (housing stock)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+# Leefbaarometer WFS endpoint (PDOK)
+LBM_WFS_URL = "https://service.pdok.nl/lbm/leefbaarometer/wfs/v1_0"
+
+# Cache settings
+CACHE_DIR = Path(__file__).parent.parent.parent / "data" / "cache" / "leefbaarometer"
+CACHE_DURATION_SECONDS = 30 * 24 * 60 * 60  # 30 days (static data)
+
+# Target municipalities
+TARGET_MUNICIPALITIES = ["0518", "1916", "0603"]
+
+
+@dataclass
+class LeefbaarometerResult:
+    """Leefbaarometer data for a neighborhood."""
+    buurt_code: str
+    lbm_score: Optional[float] = None  # Overall livability score
+    fysieke_omgeving: Optional[float] = None
+    voorzieningen: Optional[float] = None
+    veiligheid: Optional[float] = None
+    bevolkingssamenstelling: Optional[float] = None
+    woningvoorraad: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "buurt_code": self.buurt_code,
+            "lbm_score": self.lbm_score,
+            "fysieke_omgeving": self.fysieke_omgeving,
+            "voorzieningen": self.voorzieningen,
+            "veiligheid": self.veiligheid,
+            "bevolkingssamenstelling": self.bevolkingssamenstelling,
+            "woningvoorraad": self.woningvoorraad,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LeefbaarometerResult":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class LeefbaarometerCollector:
+    """
+    Collector for Leefbaarometer 3.0 neighborhood livability data.
+
+    Fetches data from PDOK WFS service for target municipalities.
+    """
+
+    cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
+    _data: Dict[str, LeefbaarometerResult] = field(default_factory=dict, init=False, repr=False)
+    _loaded: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache_path(self) -> Path:
+        return self.cache_dir / "leefbaarometer_data.json"
+
+    def _load_from_cache(self) -> bool:
+        cache_path = self._cache_path()
+        if not cache_path.exists():
+            return False
+        try:
+            with cache_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if data.get("timestamp", 0) + CACHE_DURATION_SECONDS < time.time():
+                return False
+            for code, entry in data.get("buurten", {}).items():
+                self._data[code] = LeefbaarometerResult.from_dict(entry)
+            self._loaded = True
+            return True
+        except (json.JSONDecodeError, IOError, TypeError):
+            return False
+
+    def _save_to_cache(self) -> None:
+        cache_data = {
+            "timestamp": time.time(),
+            "buurten": {code: r.to_dict() for code, r in self._data.items()},
+        }
+        try:
+            with self._cache_path().open("w", encoding="utf-8") as f:
+                json.dump(cache_data, f, ensure_ascii=False)
+        except IOError:
+            pass
+
+    def _fetch_from_wfs(self) -> None:
+        """Fetch Leefbaarometer data from PDOK WFS."""
+        for muni_code in TARGET_MUNICIPALITIES:
+            cql_filter = f"gemeentecode='{muni_code}'"
+
+            params = {
+                "service": "WFS",
+                "version": "2.0.0",
+                "request": "GetFeature",
+                "typeName": "leefbaarometer:indicatorscorebuurt",
+                "outputFormat": "application/json",
+                "CQL_FILTER": cql_filter,
+            }
+
+            try:
+                response = requests.get(LBM_WFS_URL, params=params, timeout=60)
+                response.raise_for_status()
+                data = response.json()
+
+                for feature in data.get("features", []):
+                    props = feature.get("properties", {})
+                    buurt_code = props.get("buurtcode", "")
+                    if not buurt_code:
+                        continue
+
+                    if not buurt_code.startswith("BU"):
+                        buurt_code = f"BU{buurt_code}"
+
+                    result = LeefbaarometerResult(
+                        buurt_code=buurt_code,
+                        lbm_score=_safe_float(props.get("lbm")),
+                        fysieke_omgeving=_safe_float(props.get("fys")),
+                        voorzieningen=_safe_float(props.get("vrz")),
+                        veiligheid=_safe_float(props.get("vei")),
+                        bevolkingssamenstelling=_safe_float(props.get("bev")),
+                        woningvoorraad=_safe_float(props.get("won")),
+                    )
+                    self._data[buurt_code] = result
+
+            except requests.RequestException:
+                # Graceful degradation - continue without this gemeente
+                continue
+
+        self._loaded = True
+        self._save_to_cache()
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if not self._load_from_cache():
+            self._fetch_from_wfs()
+
+    def get_buurt(self, buurt_code: str) -> Optional[LeefbaarometerResult]:
+        """Get Leefbaarometer data for a buurt."""
+        self._ensure_loaded()
+        code = buurt_code.upper().strip()
+        if not code.startswith("BU"):
+            code = f"BU{code}"
+        return self._data.get(code)
+
+    def get_all(self) -> Dict[str, LeefbaarometerResult]:
+        """Get all Leefbaarometer data."""
+        self._ensure_loaded()
+        return dict(self._data)
+
+
+def _safe_float(val: Any) -> Optional[float]:
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def create_leefbaarometer_collector(cache_dir: Optional[Path] = None) -> LeefbaarometerCollector:
+    """Factory function with default cache directory."""
+    if cache_dir is None:
+        cache_dir = Path(__file__).parent.parent.parent / "data" / "cache" / "leefbaarometer"
+    return LeefbaarometerCollector(cache_dir=cache_dir)

--- a/backend/collectors/rivm_collector.py
+++ b/backend/collectors/rivm_collector.py
@@ -1,0 +1,228 @@
+"""
+RIVM Atlas Leefomgeving Collector.
+
+Fetches environmental quality data via WMS GetFeatureInfo requests
+for neighborhood centroids. Data includes:
+- Air quality: NO2, PM2.5, PM10
+- Noise levels: road, rail, aviation
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+
+# RIVM Atlas WMS endpoint
+RIVM_WMS_URL = "https://geodata.rivm.nl/geoserver/wms"
+
+# Layers for environmental indicators
+RIVM_LAYERS = {
+    "no2_concentratie": "nsl:no2_concentratie_jaargemiddelde",
+    "pm25_concentratie": "nsl:pm25_concentratie_jaargemiddelde",
+    "pm10_concentratie": "nsl:pm10_concentratie_jaargemiddelde",
+    "geluid_weg_lden": "gm:geluid_weg_lden",
+    "geluid_rail_lden": "gm:geluid_rail_lden",
+}
+
+CACHE_DIR = Path(__file__).parent.parent.parent / "data" / "cache" / "rivm"
+CACHE_DURATION_SECONDS = 30 * 24 * 60 * 60  # 30 days
+
+# Centroids of target municipalities (approx) for initial testing
+# In production, use actual buurt centroids calculated from geometrie
+DEFAULT_CENTROIDS = {
+    "0518": (52.07, 4.30),   # Den Haag
+    "1916": (52.08, 4.38),   # Leidschendam-Voorburg
+    "0603": (52.04, 4.33),   # Rijswijk
+}
+
+
+@dataclass
+class RIVMResult:
+    """Environmental quality data for a location."""
+    buurt_code: str
+    no2_concentratie: Optional[float] = None  # µg/m³
+    pm25_concentratie: Optional[float] = None  # µg/m³
+    pm10_concentratie: Optional[float] = None  # µg/m³
+    geluid_weg_lden: Optional[float] = None  # dB
+    geluid_rail_lden: Optional[float] = None  # dB
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "buurt_code": self.buurt_code,
+            "no2_concentratie": self.no2_concentratie,
+            "pm25_concentratie": self.pm25_concentratie,
+            "pm10_concentratie": self.pm10_concentratie,
+            "geluid_weg_lden": self.geluid_weg_lden,
+            "geluid_rail_lden": self.geluid_rail_lden,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RIVMResult":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class RIVMCollector:
+    """
+    Collector for RIVM Atlas Leefomgeving environmental data.
+
+    Uses WMS GetFeatureInfo to query environmental indicators
+    at buurt centroid locations.
+    """
+
+    cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
+    min_delay: float = 0.5  # Rate limit between WMS requests
+    _data: Dict[str, RIVMResult] = field(default_factory=dict, init=False, repr=False)
+    _loaded: bool = field(default=False, init=False, repr=False)
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache_path(self) -> Path:
+        return self.cache_dir / "rivm_data.json"
+
+    def _rate_limit(self) -> None:
+        elapsed = time.time() - self._last_request
+        if elapsed < self.min_delay:
+            time.sleep(self.min_delay - elapsed)
+        self._last_request = time.time()
+
+    def _load_from_cache(self) -> bool:
+        cache_path = self._cache_path()
+        if not cache_path.exists():
+            return False
+        try:
+            with cache_path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if data.get("timestamp", 0) + CACHE_DURATION_SECONDS < time.time():
+                return False
+            for code, entry in data.get("buurten", {}).items():
+                self._data[code] = RIVMResult.from_dict(entry)
+            self._loaded = True
+            return True
+        except (json.JSONDecodeError, IOError, TypeError):
+            return False
+
+    def _save_to_cache(self) -> None:
+        cache_data = {
+            "timestamp": time.time(),
+            "buurten": {code: r.to_dict() for code, r in self._data.items()},
+        }
+        try:
+            with self._cache_path().open("w", encoding="utf-8") as f:
+                json.dump(cache_data, f, ensure_ascii=False)
+        except IOError:
+            pass
+
+    def _query_wms_point(
+        self, layer: str, lat: float, lon: float
+    ) -> Optional[float]:
+        """Query a single WMS layer at a point using GetFeatureInfo."""
+        self._rate_limit()
+
+        # Convert lat/lon to pixel coordinates in a small bbox
+        # Use a small bounding box around the point
+        delta = 0.0005
+        bbox = f"{lon - delta},{lat - delta},{lon + delta},{lat + delta}"
+
+        params = {
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetFeatureInfo",
+            "LAYERS": layer,
+            "QUERY_LAYERS": layer,
+            "INFO_FORMAT": "application/json",
+            "SRS": "EPSG:4326",
+            "BBOX": bbox,
+            "WIDTH": 101,
+            "HEIGHT": 101,
+            "X": 50,
+            "Y": 50,
+        }
+
+        try:
+            response = requests.get(RIVM_WMS_URL, params=params, timeout=15)
+            response.raise_for_status()
+            data = response.json()
+
+            features = data.get("features", [])
+            if features:
+                props = features[0].get("properties", {})
+                # Try common field names
+                for key in ["GRAY_INDEX", "value", "pixel_value", "concentratie", "lden"]:
+                    if key in props and props[key] is not None:
+                        try:
+                            return float(props[key])
+                        except (ValueError, TypeError):
+                            pass
+                # Try first numeric property
+                for val in props.values():
+                    if val is not None:
+                        try:
+                            return float(val)
+                        except (ValueError, TypeError):
+                            continue
+        except (requests.RequestException, json.JSONDecodeError):
+            pass
+
+        return None
+
+    def fetch_for_buurt(self, buurt_code: str, lat: float, lon: float) -> RIVMResult:
+        """Fetch RIVM data for a specific buurt centroid."""
+        result = RIVMResult(buurt_code=buurt_code)
+
+        for indicator, layer in RIVM_LAYERS.items():
+            value = self._query_wms_point(layer, lat, lon)
+            if value is not None:
+                setattr(result, indicator, value)
+
+        self._data[buurt_code] = result
+        return result
+
+    def fetch_for_centroids(self, centroids: Dict[str, tuple]) -> None:
+        """
+        Fetch RIVM data for multiple buurt centroids.
+
+        Parameters
+        ----------
+        centroids : dict
+            Mapping of buurt_code -> (lat, lon)
+        """
+        for buurt_code, (lat, lon) in centroids.items():
+            if buurt_code not in self._data:
+                self.fetch_for_buurt(buurt_code, lat, lon)
+
+        self._save_to_cache()
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._load_from_cache()
+        self._loaded = True
+
+    def get_buurt(self, buurt_code: str) -> Optional[RIVMResult]:
+        """Get RIVM data for a buurt (from cache only)."""
+        self._ensure_loaded()
+        code = buurt_code.upper().strip()
+        if not code.startswith("BU"):
+            code = f"BU{code}"
+        return self._data.get(code)
+
+    def get_all(self) -> Dict[str, RIVMResult]:
+        """Get all RIVM data."""
+        self._ensure_loaded()
+        return dict(self._data)
+
+
+def create_rivm_collector(cache_dir: Optional[Path] = None) -> RIVMCollector:
+    """Factory function with default cache directory."""
+    if cache_dir is None:
+        cache_dir = Path(__file__).parent.parent.parent / "data" / "cache" / "rivm"
+    return RIVMCollector(cache_dir=cache_dir)

--- a/backend/models/buurt.py
+++ b/backend/models/buurt.py
@@ -21,7 +21,7 @@ class Buurt(Base):
     wijk_code = Column(String(20))
     wijk_naam = Column(String(200))
 
-    # CBS Statistics
+    # CBS Statistics (core fields)
     inwoners = Column(Integer)
     huishoudens = Column(Integer)
     gemiddeld_inkomen = Column(Float)
@@ -29,6 +29,9 @@ class Buurt(Base):
     gasverbruik = Column(Float)
     elektraverbruik = Column(Float)
     arbeidsparticipatie = Column(Float)
+
+    # Extended indicators (JSON blob with all CBS + Leefbaarometer + RIVM data)
+    indicatoren = Column(JSON)
 
     # Computed scores (0-1 normalized)
     score_totaal = Column(Float)
@@ -38,8 +41,19 @@ class Buurt(Base):
     score_woningen = Column(Float)
     score_coverage = Column(Float)  # How much data was available for scoring
 
+    # Category scores
+    score_bereikbaarheid = Column(Float)
+    score_energie = Column(Float)
+    score_demografie = Column(Float)
+    score_leefbaarheid = Column(Float)
+
     # Leefbaarometer
     leefbaarometer_score = Column(Float)
+    leefbaarometer_fysiek = Column(Float)
+    leefbaarometer_voorzieningen = Column(Float)
+    leefbaarometer_veiligheid = Column(Float)
+    leefbaarometer_bevolking = Column(Float)
+    leefbaarometer_woningen = Column(Float)
 
     # Price statistics (from Funda data)
     median_vraagprijs = Column(Integer)

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -14,6 +14,7 @@ class ScoringService:
     Calculate composite scores for neighborhoods based on CBS indicators.
 
     Uses min-max normalization and weighted averaging.
+    Supports category-level scores for radar chart visualization.
     """
 
     def __init__(self, config_path: Optional[Path] = None):
@@ -21,11 +22,12 @@ class ScoringService:
             config_path = Path(__file__).parent.parent.parent / "config" / "scoring.yaml"
         self.config = self._load_config(config_path)
         self.indicators = self.config.get("indicators", {})
+        self.categories = self.config.get("categories", {})
 
     def _load_config(self, path: Path) -> Dict[str, Any]:
         """Load scoring configuration from YAML."""
         if not path.exists():
-            return {"indicators": {}}
+            return {"indicators": {}, "categories": {}}
         with path.open("r", encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
 
@@ -164,7 +166,48 @@ class ScoringService:
         result["score"] = scores
         result["score_coverage"] = coverages
 
+        # Calculate category scores
+        result = self._calculate_category_scores(result, weight_map)
+
         return result.sort_values("score", ascending=False)
+
+    def _calculate_category_scores(
+        self,
+        df: pd.DataFrame,
+        weight_map: Dict[str, float],
+    ) -> pd.DataFrame:
+        """
+        Calculate per-category scores (weighted average of indicators in each category).
+
+        Adds columns: score_inkomen, score_veiligheid, score_voorzieningen,
+        score_woningen, score_bereikbaarheid, score_leefbaarheid
+        """
+        for cat_id, cat_spec in self.categories.items():
+            cat_indicators = cat_spec.get("indicators", [])
+            col_name = f"score_{cat_id}"
+
+            cat_scores = []
+            for idx in range(len(df)):
+                numer = 0.0
+                denom = 0.0
+
+                for ind_id in cat_indicators:
+                    norm_col = f"{ind_id}_norm"
+                    if norm_col in df.columns:
+                        value = df.iloc[idx][norm_col]
+                        weight = weight_map.get(ind_id, 0.0)
+                        if pd.notna(value) and weight > 0:
+                            numer += value * weight
+                            denom += weight
+
+                if denom > 0:
+                    cat_scores.append(numer / denom)
+                else:
+                    cat_scores.append(pd.NA)
+
+            df[col_name] = cat_scores
+
+        return df
 
     def get_indicator_descriptions(self) -> Dict[str, str]:
         """Get descriptions for all indicators."""
@@ -179,3 +222,37 @@ class ScoringService:
             ind_id: spec.get("weight", 0.0)
             for ind_id, spec in self.indicators.items()
         }
+
+    def get_indicator_meta(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Get full metadata for all indicators.
+
+        Returns dict of indicator_id -> {label, category, unit, higher_is_better, weight, description}
+        """
+        meta = {}
+        for ind_id, spec in self.indicators.items():
+            meta[ind_id] = {
+                "label": spec.get("label", ind_id),
+                "category": spec.get("category"),
+                "unit": spec.get("unit", ""),
+                "higher_is_better": spec.get("higher_is_better", True),
+                "weight": spec.get("weight", 0.0),
+                "description": spec.get("description", ""),
+            }
+        return meta
+
+    def get_category_meta(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Get metadata for all categories.
+
+        Returns dict of category_id -> {label, color, weight, indicators}
+        """
+        meta = {}
+        for cat_id, cat_spec in self.categories.items():
+            meta[cat_id] = {
+                "label": cat_spec.get("label", cat_id),
+                "color": cat_spec.get("color", "#6b7280"),
+                "weight": cat_spec.get("weight", 0.0),
+                "indicators": cat_spec.get("indicators", []),
+            }
+        return meta

--- a/backend/services/valuation.py
+++ b/backend/services/valuation.py
@@ -19,6 +19,16 @@ class BiedAdvies(str, Enum):
     BOVEN_VRAAGPRIJS = "boven_vraagprijs"
 
 
+# Buurt quality correction based on score_totaal
+BUURT_QUALITY_CORRECTIONS = [
+    (0.80, 1.00, +0.08),   # Uitstekende buurt
+    (0.65, 0.80, +0.04),   # Goede buurt
+    (0.50, 0.65,  0.00),   # Gemiddeld (referentie)
+    (0.35, 0.50, -0.03),   # Onder gemiddeld
+    (0.00, 0.35, -0.06),   # Zwakke buurt
+]
+
+
 @dataclass
 class ValuationResult:
     """Result of a property valuation."""
@@ -43,6 +53,7 @@ class ValuationResult:
     bouwjaar_correctie: int
     woningtype_correctie: int
     perceel_correctie: int  # Plot size correction
+    buurt_kwaliteit_correctie: int  # Neighborhood quality correction
     markt_correctie: int
 
     # Confidence
@@ -62,6 +73,8 @@ class ValuationService:
                         + Energy label correction (-15% to +5%)
                         + Build year correction (new +10%, pre-1950 -5%)
                         + Property type correction (apartment -5%, detached +10%)
+                        + Plot size correction
+                        + Neighborhood quality correction (-6% to +8%)
                         ± Market conditions (current overbidding percentage)
     """
 
@@ -102,42 +115,32 @@ class ValuationService:
     }
 
     # Reference plot sizes per property type (in m²)
-    # Used to calculate plot size correction
     REFERENCE_PLOT_SIZES = {
-        "appartement": 0,  # Apartments typically don't have plots
+        "appartement": 0,
         "tussenwoning": 150,
         "hoekwoning": 200,
         "twee-onder-een-kap": 300,
         "vrijstaand": 500,
         "villa": 800,
     }
-    DEFAULT_REFERENCE_PLOT_SIZE = 150  # Default for unknown types
+    DEFAULT_REFERENCE_PLOT_SIZE = 150
 
-    # Default market overbidding percentage (can be updated from market data)
-    DEFAULT_OVERBID_PERCENTAGE = 0.05  # 5% overbidding
+    # Default market overbidding percentage
+    DEFAULT_OVERBID_PERCENTAGE = 0.05
 
-    # Regional fallback prices (per m²) when no specific data available
+    # Regional fallback prices (per m²)
     REGIONAL_M2_PRICES = {
         "0518": 5200.0,  # Den Haag
         "1916": 4800.0,  # Leidschendam-Voorburg
         "0603": 4600.0,  # Rijswijk
     }
-    DEFAULT_M2_PRICE = 4500.0  # Fallback for unknown regions
+    DEFAULT_M2_PRICE = 4500.0
 
     def __init__(self, db: Optional[Session] = None, load_prices: bool = True):
-        """
-        Initialize ValuationService.
-
-        Parameters
-        ----------
-        db : Session, optional
-            Database session for loading buurt prices
-        load_prices : bool
-            Whether to load m² prices from database on init (default: True)
-        """
         self.db = db
         self._buurt_m2_prices: Dict[str, float] = {}
         self._gemeente_m2_prices: Dict[str, float] = {}
+        self._buurt_scores: Dict[str, float] = {}
         self._market_overbid: float = self.DEFAULT_OVERBID_PERCENTAGE
         self._prices_loaded: bool = False
 
@@ -145,27 +148,27 @@ class ValuationService:
             self._load_buurt_prices()
 
     def _load_buurt_prices(self) -> None:
-        """Load neighborhood m² prices from the database."""
+        """Load neighborhood m² prices and scores from the database."""
         if not self.db or self._prices_loaded:
             return
 
         try:
-            # Load all buurten with m² prices
-            buurten = self.db.query(Buurt).filter(
-                Buurt.median_m2_prijs.isnot(None)
-            ).all()
+            buurten = self.db.query(Buurt).all()
 
             for buurt in buurten:
                 if buurt.code and buurt.median_m2_prijs:
                     self._buurt_m2_prices[buurt.code] = buurt.median_m2_prijs
 
-                    # Also aggregate by gemeente
                     if buurt.gemeente_code:
                         if buurt.gemeente_code not in self._gemeente_m2_prices:
                             self._gemeente_m2_prices[buurt.gemeente_code] = []
                         self._gemeente_m2_prices[buurt.gemeente_code].append(
                             buurt.median_m2_prijs
                         )
+
+                # Load buurt scores for quality correction
+                if buurt.code and buurt.score_totaal is not None:
+                    self._buurt_scores[buurt.code] = buurt.score_totaal
 
             # Calculate average per gemeente
             for gemeente_code, prices in list(self._gemeente_m2_prices.items()):
@@ -177,7 +180,6 @@ class ValuationService:
             self._prices_loaded = True
 
         except Exception:
-            # If loading fails, continue with defaults
             pass
 
     def get_buurt_m2_price(self, buurt_code: Optional[str]) -> tuple[float, str]:
@@ -193,14 +195,11 @@ class ValuationService:
         if buurt_code and buurt_code in self._buurt_m2_prices:
             return self._buurt_m2_prices[buurt_code], "buurt"
 
-        # Try gemeente level
         if buurt_code:
-            # Extract gemeente code from buurt code (first 4 chars typically)
             gemeente_code = buurt_code[:4] if len(buurt_code) >= 4 else None
             if gemeente_code and gemeente_code in self._gemeente_m2_prices:
                 return self._gemeente_m2_prices[gemeente_code], "gemeente"
 
-            # Try regional defaults
             for gm_code, price in self.REGIONAL_M2_PRICES.items():
                 if buurt_code.startswith(gm_code):
                     return price, "regio"
@@ -216,15 +215,12 @@ class ValuationService:
         self._market_overbid = percentage
 
     def get_energy_correction(self, label: Optional[str]) -> float:
-        """Get energy label price correction factor."""
         if not label:
             return 0.0
-        # Normalize label (remove + variants for lookup)
         normalized = label.upper().strip()
         return self.ENERGY_CORRECTIONS.get(normalized, 0.0)
 
     def get_build_year_correction(self, year: Optional[int]) -> float:
-        """Get build year price correction factor."""
         if not year:
             return 0.0
         for (start, end), correction in self.BUILD_YEAR_CORRECTIONS.items():
@@ -233,7 +229,6 @@ class ValuationService:
         return 0.0
 
     def get_type_correction(self, property_type: Optional[str]) -> float:
-        """Get property type price correction factor."""
         if not property_type:
             return 0.0
         normalized = property_type.lower().strip()
@@ -247,17 +242,9 @@ class ValuationService:
         grondoppervlakte: Optional[int],
         woningtype: Optional[str] = None,
     ) -> float:
-        """
-        Get plot size correction factor.
-
-        Compares actual plot size with reference for the property type.
-        Returns correction: +5% per 50m² above reference, max +15%.
-        Negative correction for smaller plots: -3% per 50m² below reference.
-        """
         if not grondoppervlakte or grondoppervlakte <= 0:
             return 0.0
 
-        # Get reference plot size for this property type
         reference = self.DEFAULT_REFERENCE_PLOT_SIZE
         if woningtype:
             normalized = woningtype.lower().strip()
@@ -266,21 +253,36 @@ class ValuationService:
                     reference = ref_size
                     break
 
-        # Apartments don't get plot correction
         if reference == 0:
             return 0.0
 
-        # Calculate difference from reference
         difference = grondoppervlakte - reference
 
         if difference > 0:
-            # Larger plot: +5% per 50m² above reference, max +15%
             correction = (difference / 50) * 0.05
             return min(correction, 0.15)
         else:
-            # Smaller plot: -3% per 50m² below reference, max -10%
             correction = (difference / 50) * 0.03
             return max(correction, -0.10)
+
+    def get_buurt_quality_correction(self, buurt_code: Optional[str]) -> float:
+        """
+        Get neighborhood quality correction factor based on score_totaal.
+
+        Returns correction between -0.06 and +0.08.
+        """
+        if not buurt_code:
+            return 0.0
+
+        score = self._buurt_scores.get(buurt_code)
+        if score is None:
+            return 0.0
+
+        for low, high, correction in BUURT_QUALITY_CORRECTIONS:
+            if low <= score <= high:
+                return correction
+
+        return 0.0
 
     def estimate_value(
         self,
@@ -315,6 +317,8 @@ class ValuationService:
             Current asking price for comparison
         comparables : list, optional
             List of comparable transactions for additional validation
+        grondoppervlakte : int, optional
+            Plot area in m2
 
         Returns
         -------
@@ -360,6 +364,9 @@ class ValuationService:
         perceel_factor = self.get_perceel_correction(grondoppervlakte, woningtype)
         perceel_correctie = int(basis_waarde * perceel_factor)
 
+        buurt_quality_factor = self.get_buurt_quality_correction(buurt_code)
+        buurt_kwaliteit_correctie = int(basis_waarde * buurt_quality_factor)
+
         market_correctie = int(basis_waarde * self._market_overbid)
 
         # Calculate estimated value
@@ -369,15 +376,16 @@ class ValuationService:
             + year_correctie
             + type_correctie
             + perceel_correctie
+            + buurt_kwaliteit_correctie
             + market_correctie
         )
 
         # Value range (±10%, narrower if we have good data)
         range_factor = 0.10
         if price_source == "buurt":
-            range_factor = 0.08  # More accurate with buurt data
+            range_factor = 0.08
         if comparables_m2_price:
-            range_factor = 0.07  # Even more accurate with comparables
+            range_factor = 0.07
 
         waarde_laag = int(waarde_midden * (1 - range_factor))
         waarde_hoog = int(waarde_midden * (1 + range_factor))
@@ -394,6 +402,7 @@ class ValuationService:
 
         # Calculate confidence
         has_buurt_data = price_source in ("buurt", "gemeente")
+        has_buurt_scores = buurt_code is not None and buurt_code in self._buurt_scores
         confidence, confidence_factors = self._calculate_confidence(
             buurt_m2_prijs=buurt_m2_prijs,
             energielabel=energielabel,
@@ -401,6 +410,7 @@ class ValuationService:
             woningtype=woningtype,
             has_buurt_data=has_buurt_data,
             has_comparables=bool(comparables),
+            has_buurt_scores=has_buurt_scores,
             price_source=price_source,
         )
 
@@ -418,6 +428,7 @@ class ValuationService:
             bouwjaar_correctie=year_correctie,
             woningtype_correctie=type_correctie,
             perceel_correctie=perceel_correctie,
+            buurt_kwaliteit_correctie=buurt_kwaliteit_correctie,
             markt_correctie=market_correctie,
             confidence=confidence,
             confidence_factors=confidence_factors,
@@ -433,28 +444,23 @@ class ValuationService:
     ) -> tuple[BiedAdvies, int, int]:
         """Calculate bidding advice and range."""
         if not vraagprijs:
-            # No asking price, suggest estimated value range
             return BiedAdvies.VRAAGPRIJS, waarde_laag, waarde_hoog
 
         ratio = vraagprijs / waarde_midden
 
         if ratio > 1.10:
-            # Asking price significantly above estimate
             advies = BiedAdvies.ONDER_VRAAGPRIJS
             bied_laag = waarde_laag
             bied_hoog = int(vraagprijs * 0.95)
         elif ratio > 1.02:
-            # Asking price slightly above estimate
             advies = BiedAdvies.VRAAGPRIJS
             bied_laag = int(vraagprijs * 0.98)
             bied_hoog = vraagprijs
         elif ratio > 0.95:
-            # Asking price near estimate - competitive market
             advies = BiedAdvies.LICHT_BOVEN
             bied_laag = vraagprijs
             bied_hoog = int(vraagprijs * 1.03)
         else:
-            # Asking price below estimate - likely overbidding needed
             advies = BiedAdvies.BOVEN_VRAAGPRIJS
             bied_laag = vraagprijs
             bied_hoog = int(waarde_midden * 1.05)
@@ -469,14 +475,10 @@ class ValuationService:
         woningtype: Optional[str],
         has_buurt_data: bool,
         has_comparables: bool = False,
+        has_buurt_scores: bool = False,
         price_source: str = "default",
     ) -> tuple[float, Dict[str, Any]]:
-        """
-        Calculate confidence score based on data completeness.
-
-        Returns a confidence score between 0 and 1, along with
-        detailed factors showing which data was available.
-        """
+        """Calculate confidence score based on data completeness."""
         factors: Dict[str, Any] = {
             "buurt_m2_prijs": buurt_m2_prijs is not None,
             "buurt_data": has_buurt_data,
@@ -484,26 +486,25 @@ class ValuationService:
             "bouwjaar": bouwjaar is not None,
             "woningtype": woningtype is not None,
             "comparables": has_comparables,
+            "buurt_scores": has_buurt_scores,
             "price_source": price_source,
         }
 
-        # Weights for confidence calculation
         weights = {
-            "buurt_m2_prijs": 0.20,
-            "buurt_data": 0.20,
-            "energielabel": 0.15,
-            "bouwjaar": 0.10,
-            "woningtype": 0.10,
-            "comparables": 0.25,
+            "buurt_m2_prijs": 0.18,
+            "buurt_data": 0.18,
+            "energielabel": 0.14,
+            "bouwjaar": 0.08,
+            "woningtype": 0.08,
+            "comparables": 0.24,
+            "buurt_scores": 0.10,
         }
 
-        # Calculate base confidence from boolean factors
         confidence = sum(
             weights[k] for k, v in factors.items()
             if k in weights and v is True
         )
 
-        # Bonus for higher quality price source
         source_bonus = {
             "buurt": 0.10,
             "gemeente": 0.05,
@@ -513,7 +514,6 @@ class ValuationService:
         }
         confidence += source_bonus.get(price_source, 0)
 
-        # Cap at 1.0
         confidence = min(confidence, 1.0)
 
         return confidence, factors
@@ -525,9 +525,5 @@ class ValuationService:
         woningtype: Optional[str] = None,
         limit: int = 5,
     ) -> List[Dict[str, Any]]:
-        """
-        Find comparable recently sold properties.
-
-        TODO: Implement when we have sold property data.
-        """
+        """Find comparable recently sold properties."""
         return []

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -4,46 +4,92 @@
 # CBS dataset identifiers
 datasets:
   kerncijfers: "85618NED"  # Kerncijfers wijken en buurten 2024
+  nabijheid: "80306ned"    # Nabijheid voorzieningen
   solar: "86044NED"        # Zonnestroom
   labour: "86089NED"       # Arbeidsdeelname
 
+# Category definitions for radar chart and grouping
+categories:
+  inkomen:
+    label: "Inkomen & welvaart"
+    indicators:
+      - income_per_inhabitant
+      - labour_participation
+      - adult_poverty_rate
+      - high_income_share
+    color: "#3b82f6"
+    weight: 0.20
+
+  veiligheid:
+    label: "Veiligheid"
+    indicators:
+      - crime_per_1000
+      - leefbaarometer_veiligheid
+    color: "#ef4444"
+    weight: 0.15
+
+  voorzieningen:
+    label: "Voorzieningen"
+    indicators:
+      - afstand_huisarts
+      - afstand_school
+      - afstand_supermarkt
+      - afstand_restaurant
+      - afstand_bioscoop
+      - afstand_zwembad
+      - afstand_bibliotheek
+    color: "#22c55e"
+    weight: 0.18
+
+  woningen:
+    label: "Woningkwaliteit"
+    indicators:
+      - woz_value
+      - gas_consumption
+      - bouwjaar_nieuw_pct
+      - corporatie_share
+      - huur_share
+    color: "#f59e0b"
+    weight: 0.17
+
+  bereikbaarheid:
+    label: "Bereikbaarheid"
+    indicators:
+      - cars_per_household
+      - afstand_treinstation
+      - afstand_oprit
+    color: "#8b5cf6"
+    weight: 0.12
+
+  leefbaarheid:
+    label: "Leefbaarheid"
+    indicators:
+      - leefbaarometer_score
+      - leefbaarometer_fysiek
+      - no2_concentratie
+      - pm25_concentratie
+    color: "#06b6d4"
+    weight: 0.18
+
 # Scoring indicators
 indicators:
+  # === Inkomen & welvaart ===
   income_per_inhabitant:
     column: GemiddeldInkomenPerInwoner_81
     higher_is_better: true
     weight: 0.12
+    category: inkomen
+    label: Gem. inkomen per inwoner
+    unit: euro
     description: Gemiddeld inkomen per inwoner (koopkracht)
-
-  woz_value:
-    column: GemiddeldeWOZWaardeVanWoningen_36
-    higher_is_better: false
-    weight: 0.08
-    description: Gemiddelde WOZ-waarde als proxy voor woningkwaliteit
-
-  gas_consumption:
-    column: GemiddeldAardgasverbruikTotaal_56
-    higher_is_better: false
-    weight: 0.08
-    description: Lager gasverbruik duidt op energiezuinigere woningen
-
-  electricity_consumption:
-    column: GemiddeldeElektriciteitsleveringTotaal_48
-    higher_is_better: false
-    weight: 0.04
-    description: Lager elektriciteitsverbruik per woning
-
-  cars_per_household:
-    numerator: PersonenautoSTotaal_109
-    denominator: HuishoudensTotaal_29
-    higher_is_better: false
-    weight: 0.05
-    description: Minder auto's per huishouden duidt op betere OV/bereikbaarheid
 
   labour_participation:
     column: NettoArbeidsparticipatie_3
     higher_is_better: true
     weight: 0.10
+    category: inkomen
+    label: Arbeidsparticipatie
+    unit: percentage
     description: Hogere arbeidsparticipatie wijst op economisch actieve bevolking
 
   adult_poverty_rate:
@@ -51,59 +97,277 @@ indicators:
     scope: municipality
     higher_is_better: false
     weight: 0.07
+    category: inkomen
+    label: Armoede (relatief)
+    unit: percentage
     description: Lager aandeel personen in armoede
 
+  high_income_share:
+    column: huishoudens_hoog_inkomen_pct
+    source: indicatoren
+    higher_is_better: true
+    weight: 0.04
+    category: inkomen
+    label: Huishoudens hoog inkomen
+    unit: percentage
+    description: Percentage huishoudens met een hoog inkomen
+
+  # === Veiligheid ===
   crime_per_1000:
     column: GeregistreerdeMisdrijvenPer1000Inw_3
     scope: municipality
     higher_is_better: false
     weight: 0.07
+    category: veiligheid
+    label: Misdrijven per 1.000 inwoners
+    unit: per_1000
     description: Minder geregistreerde misdrijven per 1.000 inwoners
 
-  house_price_level:
-    column: GemiddeldeVerkoopprijs_1
-    scope: municipality
+  leefbaarometer_veiligheid:
+    column: leefbaarometer_veiligheid
+    source: model
+    higher_is_better: true
+    weight: 0.05
+    category: veiligheid
+    label: Leefbaarometer veiligheid
+    unit: score
+    description: Veiligheidsscore uit Leefbaarometer 3.0
+
+  # === Voorzieningen ===
+  afstand_huisarts:
+    column: afstand_huisartsenpraktijk
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.03
+    category: voorzieningen
+    label: Afstand huisarts
+    unit: km
+    description: Afstand tot dichtstbijzijnde huisartsenpraktijk
+
+  afstand_school:
+    column: afstand_basisonderwijs
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.02
+    category: voorzieningen
+    label: Afstand basisschool
+    unit: km
+    description: Afstand tot dichtstbijzijnde basisschool
+
+  afstand_supermarkt:
+    column: afstand_grote_supermarkt
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.03
+    category: voorzieningen
+    label: Afstand supermarkt
+    unit: km
+    description: Afstand tot dichtstbijzijnde grote supermarkt
+
+  afstand_restaurant:
+    column: afstand_restaurant
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.01
+    category: voorzieningen
+    label: Afstand restaurant
+    unit: km
+    description: Afstand tot dichtstbijzijnde restaurant
+
+  afstand_bioscoop:
+    column: afstand_bioscoop
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.01
+    category: voorzieningen
+    label: Afstand bioscoop
+    unit: km
+    description: Afstand tot dichtstbijzijnde bioscoop
+
+  afstand_zwembad:
+    column: afstand_zwembad
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.01
+    category: voorzieningen
+    label: Afstand zwembad
+    unit: km
+    description: Afstand tot dichtstbijzijnde zwembad
+
+  afstand_bibliotheek:
+    column: afstand_bibliotheek
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.01
+    category: voorzieningen
+    label: Afstand bibliotheek
+    unit: km
+    description: Afstand tot dichtstbijzijnde bibliotheek
+
+  # === Woningkwaliteit ===
+  woz_value:
+    column: GemiddeldeWOZWaardeVanWoningen_36
+    higher_is_better: false
+    weight: 0.08
+    category: woningen
+    label: Gem. WOZ-waarde
+    unit: euro
+    description: Gemiddelde WOZ-waarde als proxy voor woningkwaliteit
+
+  gas_consumption:
+    column: GemiddeldAardgasverbruikTotaal_56
+    higher_is_better: false
+    weight: 0.08
+    category: woningen
+    label: Gem. gasverbruik
+    unit: m3
+    description: Lager gasverbruik duidt op energiezuinigere woningen
+
+  electricity_consumption:
+    column: GemiddeldeElektriciteitsleveringTotaal_48
     higher_is_better: false
     weight: 0.04
-    description: Lagere gemiddelde verkoopprijs kan wijzen op betaalbaarheid
+    category: woningen
+    label: Gem. elektraverbruik
+    unit: kWh
+    description: Lager elektriciteitsverbruik per woning
+
+  bouwjaar_nieuw_pct:
+    column: bouwjaar_vanaf_2000_pct
+    source: indicatoren
+    higher_is_better: true
+    weight: 0.02
+    category: woningen
+    label: "Bouwjaar ≥ 2000"
+    unit: percentage
+    description: Percentage woningen gebouwd na 2000
 
   corporatie_share:
     numerator: EigendomWoningcorporatie_4
     denominator: TotaleWoningvoorraad_1
     scope: municipality
     higher_is_better: true
-    weight: 0.08
-    description: Hoger aandeel corporatiewoningen vergroot kans op gereguleerde huur
+    weight: 0.03
+    category: woningen
+    label: Corporatiewoningen
+    unit: percentage
+    description: Hoger aandeel corporatiewoningen
 
   huur_share:
     numerator: TotaalHuurwoningen_3
     denominator: TotaleWoningvoorraad_1
     scope: municipality
     higher_is_better: true
-    weight: 0.05
-    description: Groot beschikbaar huursegment vergroot slagingskans
-
-  leefbaarometer_score:
-    column: lbm
-    higher_is_better: true
-    weight: 0.08
-    description: Algemeen leefbaarheidscijfer uit Leefbaarometer 3.0
+    weight: 0.02
+    category: woningen
+    label: Huurwoningen
+    unit: percentage
+    description: Groot beschikbaar huursegment
 
   solar_capacity:
     column: OpgesteldVermogenVanZonnepanelen_6
     higher_is_better: true
-    weight: 0.04
-    description: Meer opgesteld PV-vermogen geeft duurzame initiatieven weer
+    weight: 0.02
+    category: woningen
+    label: Zonnepaneel vermogen
+    unit: kW
+    description: Meer opgesteld PV-vermogen
 
   solar_installations:
     column: AantalInstallatiesBijWoningen_5
     higher_is_better: true
+    weight: 0.01
+    category: woningen
+    label: Zonnepaneel installaties
+    unit: aantal
+    description: Brede adoptie van zonnepanelen
+
+  # === Bereikbaarheid ===
+  cars_per_household:
+    numerator: PersonenautoSTotaal_109
+    denominator: HuishoudensTotaal_29
+    higher_is_better: false
     weight: 0.03
-    description: Veel installaties betekent brede adoptie van zonnepanelen
+    category: bereikbaarheid
+    label: "Auto's per huishouden"
+    unit: ratio
+    description: Minder auto's per huishouden duidt op betere OV/bereikbaarheid
+
+  afstand_treinstation:
+    column: afstand_treinstation
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.03
+    category: bereikbaarheid
+    label: Afstand treinstation
+    unit: km
+    description: Afstand tot dichtstbijzijnde belangrijk overstapstation
+
+  afstand_oprit:
+    column: afstand_oprit_hoofdverkeersweg
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.02
+    category: bereikbaarheid
+    label: Afstand snelweg
+    unit: km
+    description: Afstand tot oprit hoofdverkeersweg
+
+  # === Leefbaarheid ===
+  leefbaarometer_score:
+    column: lbm
+    higher_is_better: true
+    weight: 0.08
+    category: leefbaarheid
+    label: Leefbaarometer totaal
+    unit: score
+    description: Algemeen leefbaarheidscijfer uit Leefbaarometer 3.0
+
+  leefbaarometer_fysiek:
+    column: leefbaarometer_fysiek
+    source: model
+    higher_is_better: true
+    weight: 0.03
+    category: leefbaarheid
+    label: Leefbaarometer fysiek
+    unit: score
+    description: Score fysieke omgeving uit Leefbaarometer
+
+  no2_concentratie:
+    column: no2_concentratie
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.02
+    category: leefbaarheid
+    label: NO2 concentratie
+    unit: µg/m³
+    description: Lagere NO2 concentratie is beter voor gezondheid
+
+  pm25_concentratie:
+    column: pm25_concentratie
+    source: indicatoren
+    higher_is_better: false
+    weight: 0.02
+    category: leefbaarheid
+    label: Fijnstof PM2.5
+    unit: µg/m³
+    description: Lagere fijnstofconcentratie is beter voor gezondheid
+
+  # === Overig (niet in categorie, maar meegerekend) ===
+  house_price_level:
+    column: GemiddeldeVerkoopprijs_1
+    scope: municipality
+    higher_is_better: false
+    weight: 0.02
+    label: Gem. verkoopprijs
+    unit: euro
+    description: Lagere gemiddelde verkoopprijs kan wijzen op betaalbaarheid
 
   wmo_clients_per_1000:
     column: WmoClientenPer1000Inwoners_6
     scope: municipality
     higher_is_better: false
-    weight: 0.07
+    weight: 0.04
+    label: Wmo-cliënten per 1.000
+    unit: per_1000
     description: Minder Wmo-cliënten per 1.000 inwoners

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^6.21.0"
+        "react-router-dom": "^6.21.0",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.8",
@@ -760,6 +761,40 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1099,6 +1134,16 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
@@ -1164,6 +1209,60 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1189,13 +1288,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1209,6 +1308,11 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1425,6 +1529,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1456,7 +1568,117 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1475,6 +1697,11 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1492,6 +1719,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1539,6 +1771,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1656,6 +1893,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2127,6 +2381,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "peer": true
+    },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
@@ -2138,6 +2398,28 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -2199,6 +2481,50 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -2415,6 +2741,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2521,11 +2852,40 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "react-router-dom": "^6.21.0"
+    "react-router-dom": "^6.21.0",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.8",

--- a/frontend/src/components/BuurtMap.tsx
+++ b/frontend/src/components/BuurtMap.tsx
@@ -18,6 +18,29 @@ L.Icon.Default.mergeOptions({
 interface BuurtMapProps {
   gemeente?: string
   minScore?: number
+  colorIndicator?: string
+  selectedBuurten?: string[]
+  onBuurtClick?: (code: string) => void
+}
+
+// Color interpolation for dynamic indicator coloring
+function interpolateColor(value: number, min: number, max: number): string {
+  if (min === max) return '#9ca3af'
+  const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)))
+  // Red (low) -> Yellow (mid) -> Green (high)
+  if (ratio < 0.5) {
+    const t = ratio * 2
+    const r = 239
+    const g = Math.round(68 + t * (163 - 68))
+    const b = Math.round(68 + t * (0 - 68))
+    return `rgb(${r},${g},${b})`
+  } else {
+    const t = (ratio - 0.5) * 2
+    const r = Math.round(234 - t * (234 - 34))
+    const g = Math.round(179 + t * (197 - 179))
+    const b = Math.round(8 + t * (94 - 8))
+    return `rgb(${r},${g},${b})`
+  }
 }
 
 function getScoreColor(score: number | null | undefined): string {
@@ -27,13 +50,20 @@ function getScoreColor(score: number | null | undefined): string {
   return '#ef4444' // red
 }
 
-export default function BuurtMap({ gemeente, minScore }: BuurtMapProps) {
+export default function BuurtMap({
+  gemeente,
+  minScore,
+  colorIndicator = 'score_totaal',
+  selectedBuurten = [],
+  onBuurtClick,
+}: BuurtMapProps) {
   const { data: buurtenGeoJSON } = useQuery({
-    queryKey: ['buurten-geojson', gemeente, minScore],
+    queryKey: ['buurten-geojson', gemeente, minScore, colorIndicator],
     queryFn: () =>
       fetchBuurtenGeoJSON({
         gemeente: gemeente || undefined,
         min_score: minScore,
+        indicator: colorIndicator !== 'score_totaal' ? colorIndicator : undefined,
       }),
   })
 
@@ -42,10 +72,32 @@ export default function BuurtMap({ gemeente, minScore }: BuurtMapProps) {
     queryFn: fetchWoningenGeoJSON,
   })
 
+  // Calculate min/max for dynamic coloring
+  const { minVal, maxVal } = useMemo(() => {
+    if (!buurtenGeoJSON?.features) return { minVal: 0, maxVal: 1 }
+
+    const values = buurtenGeoJSON.features
+      .map((f) => {
+        if (colorIndicator === 'score_totaal') return f.properties.score_totaal as number
+        return f.properties.indicator_value as number
+      })
+      .filter((v): v is number => v !== null && v !== undefined && !isNaN(v))
+
+    if (values.length === 0) return { minVal: 0, maxVal: 1 }
+    return { minVal: Math.min(...values), maxVal: Math.max(...values) }
+  }, [buurtenGeoJSON, colorIndicator])
+
   // Key to force GeoJSON re-render on data change
   const geoJsonKey = useMemo(
-    () => JSON.stringify({ gemeente, minScore, count: buurtenGeoJSON?.features?.length }),
-    [gemeente, minScore, buurtenGeoJSON]
+    () =>
+      JSON.stringify({
+        gemeente,
+        minScore,
+        colorIndicator,
+        selectedBuurten,
+        count: buurtenGeoJSON?.features?.length,
+      }),
+    [gemeente, minScore, colorIndicator, selectedBuurten, buurtenGeoJSON]
   )
 
   const woningMarkers = useMemo(() => {
@@ -62,7 +114,7 @@ export default function BuurtMap({ gemeente, minScore }: BuurtMapProps) {
   }, [woningenGeoJSON])
 
   return (
-    <div className="rounded-lg overflow-hidden shadow mb-6" style={{ height: 400 }}>
+    <div className="rounded-lg overflow-hidden shadow mb-6 relative" style={{ height: 500 }}>
       <MapContainer
         center={[52.07, 4.3]}
         zoom={12}
@@ -79,23 +131,54 @@ export default function BuurtMap({ gemeente, minScore }: BuurtMapProps) {
             key={geoJsonKey}
             data={buurtenGeoJSON as GeoJSON.FeatureCollection}
             style={(feature) => {
-              const score = feature?.properties?.score_totaal
+              const p = feature?.properties
+              const isSelected = selectedBuurten.includes(p?.code as string)
+
+              let fillColor: string
+              if (colorIndicator === 'score_totaal') {
+                fillColor = getScoreColor(p?.score_totaal as number)
+              } else {
+                const val = p?.indicator_value as number
+                if (val === null || val === undefined) {
+                  fillColor = '#9ca3af'
+                } else {
+                  fillColor = interpolateColor(val, minVal, maxVal)
+                }
+              }
+
               return {
-                fillColor: getScoreColor(score),
-                fillOpacity: 0.3,
-                color: getScoreColor(score),
-                weight: 2,
+                fillColor,
+                fillOpacity: isSelected ? 0.6 : 0.3,
+                color: isSelected ? '#1e40af' : fillColor,
+                weight: isSelected ? 4 : 2,
               }
             }}
             onEachFeature={(feature, layer) => {
               const p = feature.properties
-              const score = p.score_totaal != null ? Math.round(p.score_totaal * 100) : '-'
-              const prijs = p.median_vraagprijs ? formatPrijs(p.median_vraagprijs) : '-'
+              const score = p.score_totaal != null ? Math.round((p.score_totaal as number) * 100) : '-'
+              const prijs = p.median_vraagprijs ? formatPrijs(p.median_vraagprijs as number) : '-'
+
+              let indicatorText = ''
+              if (colorIndicator !== 'score_totaal' && p.indicator_value != null) {
+                indicatorText = `<br/>${colorIndicator}: ${p.indicator_value}`
+              }
+
+              // Tooltip with key stats
+              const inkomen = p.score_inkomen != null ? Math.round((p.score_inkomen as number) * 100) : '-'
+              const veiligheid = p.score_veiligheid != null ? Math.round((p.score_veiligheid as number) * 100) : '-'
+
               layer.bindPopup(
                 `<strong>${p.naam}</strong><br/>` +
-                  `Score: ${score}<br/>` +
-                  `Mediaan: ${prijs}`
+                  `Score: ${score} | Inkomen: ${inkomen} | Veiligheid: ${veiligheid}<br/>` +
+                  `Mediaan: ${prijs}` +
+                  indicatorText
               )
+
+              if (onBuurtClick) {
+                layer.on('click', () => {
+                  onBuurtClick(p.code as string)
+                })
+              }
             }}
           />
         )}
@@ -115,6 +198,28 @@ export default function BuurtMap({ gemeente, minScore }: BuurtMapProps) {
           )
         })}
       </MapContainer>
+
+      {/* Color Legend */}
+      <div className="absolute bottom-4 right-4 bg-white bg-opacity-90 rounded-lg shadow px-3 py-2 z-[1000]">
+        <div className="text-xs font-medium text-gray-700 mb-1">
+          {colorIndicator === 'score_totaal' ? 'Score' : colorIndicator}
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-500">
+            {colorIndicator === 'score_totaal' ? '0' : minVal.toFixed(1)}
+          </span>
+          <div
+            className="h-3 rounded"
+            style={{
+              width: 80,
+              background: 'linear-gradient(to right, #ef4444, #eab308, #22c55e)',
+            }}
+          />
+          <span className="text-xs text-gray-500">
+            {colorIndicator === 'score_totaal' ? '100' : maxVal.toFixed(1)}
+          </span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/BuurtVergelijker.tsx
+++ b/frontend/src/components/BuurtVergelijker.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Legend,
+  Tooltip,
+} from 'recharts'
+import {
+  fetchBuurtenVergelijk,
+  fetchIndicatorMeta,
+  Buurt,
+  CategoryMeta,
+  IndicatorMeta,
+  formatPrijs,
+} from '../services/api'
+
+const BUURT_COLORS = ['#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#8b5cf6']
+
+interface BuurtVergelijkerProps {
+  selectedCodes: string[]
+}
+
+export default function BuurtVergelijker({ selectedCodes }: BuurtVergelijkerProps) {
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(['inkomen', 'veiligheid']))
+
+  const { data: vergelijkData, isLoading } = useQuery({
+    queryKey: ['buurten-vergelijk', selectedCodes],
+    queryFn: () => fetchBuurtenVergelijk(selectedCodes),
+    enabled: selectedCodes.length >= 2,
+  })
+
+  const { data: metaData } = useQuery({
+    queryKey: ['indicator-meta'],
+    queryFn: fetchIndicatorMeta,
+  })
+
+  const buurten = vergelijkData?.buurten ?? []
+  const categories = vergelijkData?.categories ?? metaData?.categories ?? {}
+  const indicators = metaData?.indicators ?? {}
+
+  // Prepare radar chart data
+  const radarData = useMemo(() => {
+    if (!buurten.length) return []
+    const categoryKeys = Object.keys(categories)
+    return categoryKeys.map((catId) => {
+      const entry: Record<string, unknown> = {
+        category: categories[catId]?.label ?? catId,
+      }
+      buurten.forEach((buurt) => {
+        const scoreKey = `score_${catId}` as keyof Buurt
+        const val = buurt[scoreKey]
+        entry[buurt.code] = typeof val === 'number' ? Math.round(val * 100) : 0
+      })
+      return entry
+    })
+  }, [buurten, categories])
+
+  if (selectedCodes.length < 2) {
+    return (
+      <div className="bg-gray-50 rounded-lg p-8 text-center text-gray-500 mb-6">
+        Selecteer minimaal 2 buurten om te vergelijken (klik op de kaart of gebruik de zoekbalk)
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-8 text-center text-gray-500 mb-6 animate-pulse">
+        Vergelijking laden...
+      </div>
+    )
+  }
+
+  if (!buurten.length) return null
+
+  const toggleCategory = (catId: string) => {
+    setExpandedCategories((prev) => {
+      const next = new Set(prev)
+      if (next.has(catId)) next.delete(catId)
+      else next.add(catId)
+      return next
+    })
+  }
+
+  return (
+    <div className="space-y-6 mb-6">
+      {/* Radar Chart */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Buurtprofiel vergelijking</h3>
+        <div style={{ width: '100%', height: 400 }}>
+          <ResponsiveContainer>
+            <RadarChart data={radarData}>
+              <PolarGrid />
+              <PolarAngleAxis dataKey="category" tick={{ fontSize: 12 }} />
+              <PolarRadiusAxis angle={30} domain={[0, 100]} tick={{ fontSize: 10 }} />
+              {buurten.map((buurt, idx) => (
+                <Radar
+                  key={buurt.code}
+                  name={buurt.naam}
+                  dataKey={buurt.code}
+                  stroke={BUURT_COLORS[idx % BUURT_COLORS.length]}
+                  fill={BUURT_COLORS[idx % BUURT_COLORS.length]}
+                  fillOpacity={0.15}
+                  strokeWidth={2}
+                />
+              ))}
+              <Legend />
+              <Tooltip />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      {/* Comparison Table */}
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <div className="p-4 border-b">
+          <h3 className="text-lg font-semibold text-gray-900">Gedetailleerde vergelijking</h3>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="text-left px-4 py-3 font-medium text-gray-700 min-w-[200px]">Indicator</th>
+                {buurten.map((buurt, idx) => (
+                  <th key={buurt.code} className="text-right px-4 py-3 font-medium min-w-[140px]">
+                    <span style={{ color: BUURT_COLORS[idx % BUURT_COLORS.length] }}>
+                      {buurt.naam}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {/* Total score row */}
+              <tr className="bg-primary-50 font-semibold">
+                <td className="px-4 py-2 text-gray-900">Score totaal</td>
+                {buurten.map((buurt) => (
+                  <td key={buurt.code} className="text-right px-4 py-2">
+                    {buurt.score_totaal != null ? Math.round(buurt.score_totaal * 100) : '-'}
+                  </td>
+                ))}
+              </tr>
+
+              {/* Category sections */}
+              {Object.entries(categories).map(([catId, cat]) => (
+                <CategorySection
+                  key={catId}
+                  catId={catId}
+                  cat={cat}
+                  buurten={buurten}
+                  indicators={indicators}
+                  expanded={expandedCategories.has(catId)}
+                  onToggle={() => toggleCategory(catId)}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CategorySection({
+  catId,
+  cat,
+  buurten,
+  indicators,
+  expanded,
+  onToggle,
+}: {
+  catId: string
+  cat: CategoryMeta
+  buurten: Buurt[]
+  indicators: Record<string, IndicatorMeta>
+  expanded: boolean
+  onToggle: () => void
+}) {
+  return (
+    <>
+      {/* Category header */}
+      <tr
+        className="bg-gray-50 cursor-pointer hover:bg-gray-100 transition-colors"
+        onClick={onToggle}
+      >
+        <td className="px-4 py-2 font-medium text-gray-800">
+          <span className="inline-block w-3 h-3 rounded-full mr-2" style={{ backgroundColor: cat.color }} />
+          {cat.label}
+          <span className="ml-2 text-xs text-gray-400">{expanded ? '▼' : '▶'}</span>
+        </td>
+        {buurten.map((buurt) => {
+          const scoreKey = `score_${catId}` as keyof Buurt
+          const val = buurt[scoreKey]
+          return (
+            <td key={buurt.code} className="text-right px-4 py-2 font-medium">
+              {typeof val === 'number' ? Math.round(val * 100) : '-'}
+            </td>
+          )
+        })}
+      </tr>
+
+      {/* Indicator rows */}
+      {expanded &&
+        cat.indicators.map((indId) => {
+          const indMeta = indicators[indId]
+          if (!indMeta) return null
+
+          const values = buurten.map((buurt) => {
+            return getIndicatorValue(buurt, indId)
+          })
+
+          const numericValues = values.filter((v): v is number => v !== null && v !== undefined)
+          const best = numericValues.length > 0
+            ? (indMeta.higher_is_better ? Math.max(...numericValues) : Math.min(...numericValues))
+            : null
+          const worst = numericValues.length > 0
+            ? (indMeta.higher_is_better ? Math.min(...numericValues) : Math.max(...numericValues))
+            : null
+
+          return (
+            <tr key={indId} className="hover:bg-gray-50">
+              <td className="px-4 py-1.5 pl-9 text-gray-600">{indMeta.label}</td>
+              {values.map((val, idx) => {
+                const isBest = val !== null && val === best && numericValues.length > 1
+                const isWorst = val !== null && val === worst && numericValues.length > 1
+                return (
+                  <td
+                    key={buurten[idx].code}
+                    className={`text-right px-4 py-1.5 ${
+                      isBest ? 'text-green-700 font-medium' : isWorst ? 'text-red-600' : 'text-gray-700'
+                    }`}
+                  >
+                    {formatIndicatorValue(val, indMeta.unit)}
+                  </td>
+                )
+              })}
+            </tr>
+          )
+        })}
+    </>
+  )
+}
+
+function getIndicatorValue(buurt: Buurt, indicatorId: string): number | null {
+  // Check direct buurt fields first
+  const directMap: Record<string, keyof Buurt> = {
+    leefbaarometer_score: 'leefbaarometer_score',
+    leefbaarometer_veiligheid: 'leefbaarometer_veiligheid',
+    leefbaarometer_fysiek: 'leefbaarometer_fysiek',
+  }
+
+  if (directMap[indicatorId]) {
+    const val = buurt[directMap[indicatorId]]
+    return typeof val === 'number' ? val : null
+  }
+
+  // Check indicatoren JSON
+  if (buurt.indicatoren && indicatorId in buurt.indicatoren) {
+    return buurt.indicatoren[indicatorId] ?? null
+  }
+
+  // Map scoring yaml column names to buurt fields
+  const fieldMap: Record<string, keyof Buurt> = {
+    income_per_inhabitant: 'gemiddeld_inkomen',
+    woz_value: 'woz_waarde',
+  }
+
+  if (fieldMap[indicatorId]) {
+    const val = buurt[fieldMap[indicatorId]]
+    return typeof val === 'number' ? val : null
+  }
+
+  return null
+}
+
+function formatIndicatorValue(val: number | null, unit: string): string {
+  if (val === null || val === undefined) return '-'
+
+  switch (unit) {
+    case 'euro':
+      return formatPrijs(val)
+    case 'percentage':
+      return `${val.toFixed(1)}%`
+    case 'km':
+      return `${val.toFixed(1)} km`
+    case 'per_1000':
+      return `${val.toFixed(1)}`
+    case 'score':
+      return val.toFixed(2)
+    case 'ratio':
+      return val.toFixed(2)
+    case 'µg/m³':
+      return `${val.toFixed(1)} µg/m³`
+    default:
+      return typeof val === 'number' && !Number.isInteger(val) ? val.toFixed(1) : String(val)
+  }
+}

--- a/frontend/src/pages/BuurtenPage.tsx
+++ b/frontend/src/pages/BuurtenPage.tsx
@@ -1,8 +1,16 @@
-import { useState, lazy, Suspense } from 'react'
+import { useState, useMemo, lazy, Suspense } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { fetchBuurten, Buurt, formatPrijs } from '../services/api'
+import {
+  fetchBuurten,
+  fetchIndicatorMeta,
+  Buurt,
+  formatPrijs,
+} from '../services/api'
 
 const BuurtMap = lazy(() => import('../components/BuurtMap'))
+const BuurtVergelijker = lazy(() => import('../components/BuurtVergelijker'))
+
+const MAX_SELECTED = 5
 
 export function ScoreBar({ score, label }: { score?: number; label: string }) {
   if (score === undefined || score === null) {
@@ -37,9 +45,22 @@ export function ScoreBar({ score, label }: { score?: number; label: string }) {
   )
 }
 
-function BuurtCard({ buurt }: { buurt: Buurt }) {
+function BuurtCard({
+  buurt,
+  isSelected,
+  onToggle,
+}: {
+  buurt: Buurt
+  isSelected: boolean
+  onToggle: () => void
+}) {
   return (
-    <div className="bg-white rounded-lg shadow hover:shadow-md transition-shadow p-4">
+    <div
+      className={`bg-white rounded-lg shadow hover:shadow-md transition-shadow p-4 cursor-pointer border-2 ${
+        isSelected ? 'border-primary-500 ring-2 ring-primary-200' : 'border-transparent'
+      }`}
+      onClick={onToggle}
+    >
       <div className="flex justify-between items-start mb-3">
         <div>
           <h3 className="font-semibold text-gray-900">{buurt.naam}</h3>
@@ -83,6 +104,9 @@ function BuurtCard({ buurt }: { buurt: Buurt }) {
 export default function BuurtenPage() {
   const [gemeente, setGemeente] = useState<string>('')
   const [minScore, setMinScore] = useState<number | undefined>()
+  const [colorIndicator, setColorIndicator] = useState<string>('score_totaal')
+  const [selectedBuurten, setSelectedBuurten] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
 
   const { data: buurten, isLoading, error } = useQuery({
     queryKey: ['buurten', gemeente, minScore],
@@ -90,18 +114,86 @@ export default function BuurtenPage() {
       fetchBuurten({
         gemeente: gemeente || undefined,
         min_score: minScore,
-        limit: 100,
+        limit: 200,
       }),
   })
+
+  const { data: indicatorMeta } = useQuery({
+    queryKey: ['indicator-meta'],
+    queryFn: fetchIndicatorMeta,
+  })
+
+  // Build indicator options for dropdown
+  const indicatorOptions = useMemo(() => {
+    const options: { value: string; label: string; category?: string }[] = [
+      { value: 'score_totaal', label: 'Score totaal' },
+    ]
+
+    if (indicatorMeta) {
+      // Add category scores
+      for (const [catId, cat] of Object.entries(indicatorMeta.categories)) {
+        options.push({ value: `score_${catId}`, label: `Score: ${cat.label}` })
+      }
+
+      // Add individual indicators grouped by category
+      for (const [indId, ind] of Object.entries(indicatorMeta.indicators)) {
+        options.push({
+          value: indId,
+          label: ind.label,
+          category: ind.category || undefined,
+        })
+      }
+    }
+
+    return options
+  }, [indicatorMeta])
+
+  // Filter buurten by search query
+  const filteredBuurten = useMemo(() => {
+    if (!buurten) return []
+    if (!searchQuery.trim()) return buurten
+    const q = searchQuery.toLowerCase()
+    return buurten.filter(
+      (b) => b.naam.toLowerCase().includes(q) || b.code.toLowerCase().includes(q)
+    )
+  }, [buurten, searchQuery])
+
+  // Search suggestions
+  const searchSuggestions = useMemo(() => {
+    if (!buurten || searchQuery.length < 2) return []
+    const q = searchQuery.toLowerCase()
+    return buurten
+      .filter((b) => b.naam.toLowerCase().includes(q) && !selectedBuurten.includes(b.code))
+      .slice(0, 5)
+  }, [buurten, searchQuery, selectedBuurten])
+
+  const handleBuurtToggle = (code: string) => {
+    setSelectedBuurten((prev) => {
+      if (prev.includes(code)) {
+        return prev.filter((c) => c !== code)
+      }
+      if (prev.length >= MAX_SELECTED) return prev
+      return [...prev, code]
+    })
+  }
+
+  const handleSearchSelect = (code: string) => {
+    if (!selectedBuurten.includes(code) && selectedBuurten.length < MAX_SELECTED) {
+      setSelectedBuurten((prev) => [...prev, code])
+    }
+    setSearchQuery('')
+  }
 
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900 mb-2">Buurten</h1>
-      <p className="text-gray-600 mb-8">Vergelijk buurten op basis van CBS statistieken</p>
+      <p className="text-gray-600 mb-8">
+        Vergelijk buurten op basis van CBS statistieken, Leefbaarometer en meer
+      </p>
 
-      {/* Filters */}
+      {/* Filters + Indicator Selector */}
       <div className="bg-white rounded-lg shadow p-4 mb-6">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Gemeente</label>
             <select
@@ -130,12 +222,92 @@ export default function BuurtenPage() {
               className="w-full px-3 py-2 border border-gray-300 rounded-lg"
             />
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Kleur op basis van</label>
+            <select
+              value={colorIndicator}
+              onChange={(e) => setColorIndicator(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+            >
+              {indicatorOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Zoek buurt</label>
+            <div className="relative">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Zoek op naam..."
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+              {searchSuggestions.length > 0 && (
+                <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                  {searchSuggestions.map((buurt) => (
+                    <button
+                      key={buurt.code}
+                      onClick={() => handleSearchSelect(buurt.code)}
+                      className="w-full text-left px-3 py-2 hover:bg-primary-50 text-sm"
+                    >
+                      <span className="font-medium">{buurt.naam}</span>
+                      <span className="text-gray-400 ml-2">{buurt.gemeente_naam}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
 
+      {/* Selected buurten chips */}
+      {selectedBuurten.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          <span className="text-sm text-gray-500 self-center">Geselecteerd:</span>
+          {selectedBuurten.map((code) => {
+            const buurt = buurten?.find((b) => b.code === code)
+            return (
+              <span
+                key={code}
+                className="inline-flex items-center px-3 py-1 rounded-full text-sm bg-primary-100 text-primary-800"
+              >
+                {buurt?.naam || code}
+                <button
+                  onClick={() => handleBuurtToggle(code)}
+                  className="ml-2 text-primary-600 hover:text-primary-800"
+                >
+                  &times;
+                </button>
+              </span>
+            )
+          })}
+          {selectedBuurten.length < MAX_SELECTED && (
+            <span className="text-xs text-gray-400 self-center">
+              (max {MAX_SELECTED}, klik op kaart of zoek)
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Kaart */}
-      <Suspense fallback={<div className="h-[400px] bg-gray-100 rounded-lg animate-pulse mb-6" />}>
-        <BuurtMap gemeente={gemeente || undefined} minScore={minScore} />
+      <Suspense fallback={<div className="h-[500px] bg-gray-100 rounded-lg animate-pulse mb-6" />}>
+        <BuurtMap
+          gemeente={gemeente || undefined}
+          minScore={minScore}
+          colorIndicator={colorIndicator}
+          selectedBuurten={selectedBuurten}
+          onBuurtClick={handleBuurtToggle}
+        />
+      </Suspense>
+
+      {/* Vergelijker */}
+      <Suspense fallback={null}>
+        <BuurtVergelijker selectedCodes={selectedBuurten} />
       </Suspense>
 
       {/* Results */}
@@ -149,18 +321,23 @@ export default function BuurtenPage() {
         </div>
       )}
 
-      {buurten && buurten.length === 0 && (
+      {filteredBuurten && filteredBuurten.length === 0 && !isLoading && (
         <div className="text-center py-12 text-gray-500">
           Geen buurten gevonden met deze filters.
         </div>
       )}
 
-      {buurten && buurten.length > 0 && (
+      {filteredBuurten && filteredBuurten.length > 0 && (
         <>
-          <div className="text-sm text-gray-500 mb-4">{buurten.length} buurten gevonden</div>
+          <div className="text-sm text-gray-500 mb-4">{filteredBuurten.length} buurten gevonden</div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {buurten.map((buurt) => (
-              <BuurtCard key={buurt.code} buurt={buurt} />
+            {filteredBuurten.map((buurt) => (
+              <BuurtCard
+                key={buurt.code}
+                buurt={buurt}
+                isSelected={selectedBuurten.includes(buurt.code)}
+                onToggle={() => handleBuurtToggle(buurt.code)}
+              />
             ))}
           </div>
         </>

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -403,6 +403,14 @@ function AnalyseColumn({ result, onCopy, copied }: {
               </span>
             </div>
           )}
+          {result.buurt_kwaliteit_correctie !== 0 && (
+            <div className="flex justify-between">
+              <span className="text-gray-600">Buurtcorrectie (kwaliteit)</span>
+              <span className={result.buurt_kwaliteit_correctie >= 0 ? 'text-green-600' : 'text-red-600'}>
+                {result.buurt_kwaliteit_correctie >= 0 ? '+' : ''}{formatPrijs(result.buurt_kwaliteit_correctie)}
+              </span>
+            </div>
+          )}
           <div className="flex justify-between">
             <span className="text-gray-600">Marktcorrectie (overbieden)</span>
             <span className="text-green-600">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -23,6 +23,7 @@ export interface WaardebepalingResponse {
   bouwjaar_correctie: number
   woningtype_correctie: number
   perceel_correctie: number
+  buurt_kwaliteit_correctie: number
   markt_correctie: number
   confidence: number
   confidence_factors: Record<string, unknown>
@@ -125,6 +126,7 @@ export interface EnhancedWaardebepalingResponse {
   bouwjaar_correctie: number
   woningtype_correctie: number
   perceel_correctie: number
+  buurt_kwaliteit_correctie: number
   markt_correctie: number
   confidence: number
   confidence_factors: Record<string, unknown>
@@ -181,8 +183,27 @@ export interface Buurt {
   naam: string
   gemeente_naam?: string
   score_totaal?: number
+  score_inkomen?: number
+  score_veiligheid?: number
+  score_voorzieningen?: number
+  score_woningen?: number
+  score_bereikbaarheid?: number
+  score_leefbaarheid?: number
+  score_coverage?: number
   median_vraagprijs?: number
+  median_m2_prijs?: number
   aantal_te_koop?: number
+  inwoners?: number
+  huishoudens?: number
+  gemiddeld_inkomen?: number
+  woz_waarde?: number
+  leefbaarometer_score?: number
+  leefbaarometer_fysiek?: number
+  leefbaarometer_voorzieningen?: number
+  leefbaarometer_veiligheid?: number
+  leefbaarometer_bevolking?: number
+  leefbaarometer_woningen?: number
+  indicatoren?: Record<string, number>
 }
 
 export interface WatchlistItem {
@@ -195,6 +216,33 @@ export interface WatchlistItem {
   woning_vraagprijs?: number
   woning_woonoppervlakte?: number
   added_at: string
+}
+
+// Indicator metadata types
+export interface IndicatorMeta {
+  label: string
+  category?: string
+  unit: string
+  higher_is_better: boolean
+  weight: number
+  description: string
+}
+
+export interface CategoryMeta {
+  label: string
+  color: string
+  weight: number
+  indicators: string[]
+}
+
+export interface IndicatorMetaResponse {
+  indicators: Record<string, IndicatorMeta>
+  categories: Record<string, CategoryMeta>
+}
+
+export interface BuurtVergelijkResponse {
+  buurten: Buurt[]
+  categories: Record<string, CategoryMeta>
 }
 
 // Waardebepaling
@@ -364,6 +412,26 @@ export async function fetchBuurt(code: string): Promise<Buurt> {
   return response.json()
 }
 
+export async function fetchIndicatorMeta(): Promise<IndicatorMetaResponse> {
+  const response = await fetch(`${API_BASE}/buurten/indicatoren/meta`)
+  if (!response.ok) {
+    throw new Error('Indicator metadata ophalen mislukt')
+  }
+  return response.json()
+}
+
+export async function fetchBuurtenVergelijk(
+  codes: string[]
+): Promise<BuurtVergelijkResponse> {
+  const searchParams = new URLSearchParams()
+  codes.forEach((c) => searchParams.append('codes', c))
+  const response = await fetch(`${API_BASE}/buurten/vergelijk/?${searchParams}`)
+  if (!response.ok) {
+    throw new Error('Buurtenvergelijking ophalen mislukt')
+  }
+  return response.json()
+}
+
 // Watchlist
 export async function fetchWatchlist(): Promise<WatchlistItem[]> {
   const response = await fetch(`${API_BASE}/watchlist`)
@@ -416,6 +484,7 @@ export async function updateWatchlistItem(
 export async function fetchBuurtenGeoJSON(params?: {
   gemeente?: string
   min_score?: number
+  indicator?: string
 }): Promise<GeoJSONFeatureCollection> {
   const searchParams = new URLSearchParams()
   if (params) {


### PR DESCRIPTION
## Summary

- **4 nieuwe data collectors**: CBS uitgebreid (~50 indicatoren), Leefbaarometer 3.0 (PDOK WFS), CBS Nabijheid (80306ned), RIVM Atlas Leefomgeving (luchtkwaliteit/geluid)
- **Buurtenvergelijker**: radar chart + gedetailleerde tabel met 6 categorieën (inkomen, veiligheid, voorzieningen, woningen, bereikbaarheid, leefbaarheid)
- **Kaart indicator-kiezer**: dynamische kleuring per indicator met legenda, buurt selectie via klik + zoekbalk
- **Waardebepaling**: buurt kwaliteitscorrectie (-6% tot +8%) op basis van score_totaal

Closes #3, Closes #5

## Test plan

- [ ] `cd backend && python bulk_buurt_data.py` draait succesvol
- [ ] `GET /api/buurten/indicatoren/meta` retourneert indicator + categorie metadata
- [ ] `GET /api/buurten/geojson?indicator=gem_inkomen` retourneert waarden per feature
- [ ] Kaart kleurt correct op geselecteerde indicator met legenda
- [ ] Klik op buurt + zoekbalk voegt toe aan vergelijking (max 5)
- [ ] Radar chart toont 6 categorie-assen voor ≥2 geselecteerde buurten
- [ ] Vergelijkingstabel toont alle indicatoren per categorie
- [ ] Waardebepaling toont buurtcorrectie in breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)