### PR TITLE
feat: bestemmingsplan en omgevingsanalyse integratie (DSO API)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,10 @@ EP_ONLINE_API_KEY=your_ep_online_api_key_here
 # Get your free API key at: https://openrouteservice.org/dev/#/signup
 ORS_API_KEY=your_ors_api_key_here
 
-# DSO Ruimtelijke Plannen API Key (bestemmingsplannen/omgevingsplannen)
-# Request your API key at: https://developer.omgevingswet.overheid.nl/formulieren/api-key-aanvragen-0/
+# DSO API Key (Informatiepunt Leefomgeving - productieomgeving)
+# Data en services van het Digitaal Stelsel Omgevingswet
 DSO_API_KEY=your_dso_api_key_here
+
+# Ruimtelijke Plannen API Key (Informatiepunt Leefomgeving)
+# Bestemmingsplannen en omgevingsplannen
+RUIMTELIJKE_PLANNEN_API_KEY=your_ruimtelijke_plannen_api_key_here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,7 @@ EP_ONLINE_API_KEY=your_ep_online_api_key_here
 # OpenRouteService API Key (cycling routes)
 # Get your free API key at: https://openrouteservice.org/dev/#/signup
 ORS_API_KEY=your_ors_api_key_here
+
+# DSO Ruimtelijke Plannen API Key (bestemmingsplannen/omgevingsplannen)
+# Request your API key at: https://developer.omgevingswet.overheid.nl/formulieren/api-key-aanvragen-0/
+DSO_API_KEY=your_dso_api_key_here

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -10,6 +10,7 @@ from api.voorzieningen import router as voorzieningen_router
 from api.postcode6 import router as postcode6_router
 from api.bereikbaarheid import router as bereikbaarheid_router
 from api.milieu import router as milieu_router
+from api.bestemmingsplan import router as bestemmingsplan_router
 
 __all__ = [
     "buurten_router",
@@ -22,4 +23,5 @@ __all__ = [
     "postcode6_router",
     "bereikbaarheid_router",
     "milieu_router",
+    "bestemmingsplan_router",
 ]

--- a/backend/api/bestemmingsplan.py
+++ b/backend/api/bestemmingsplan.py
@@ -1,0 +1,371 @@
+"""Bestemmingsplan API routes."""
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from collectors.bestemmingsplan_collector import create_bestemmingsplan_collector
+from models.database import get_db
+from models.woning import Woning
+
+router = APIRouter(prefix="/api/bestemmingsplan", tags=["bestemmingsplan"])
+
+
+# --- Response Models ---
+
+
+class MaatvoeringResponse(BaseModel):
+    naam: str
+    waarde: str
+    eenheid: Optional[str] = None
+    waarde_type: Optional[str] = None
+
+
+class BouwvlakResponse(BaseModel):
+    geometrie: Optional[Dict[str, Any]] = None
+    maatvoeringen: List[MaatvoeringResponse] = []
+
+
+class OntwerpPlanResponse(BaseModel):
+    naam: str = ""
+    type: str = ""
+    status: str = ""
+    datum: str = ""
+    id: str = ""
+
+
+class BestemmingsplanResponse(BaseModel):
+    # Plan metadata
+    plan_naam: str
+    plan_type: str
+    plan_status: str
+    datum_vaststelling: Optional[str] = None
+
+    # Bestemming
+    bestemming: str
+    bestemming_specifiek: Optional[str] = None
+
+    # Bouwregels
+    max_bouwhoogte: Optional[float] = None
+    max_goothoogte: Optional[float] = None
+    max_bebouwingspercentage: Optional[int] = None
+    max_inhoud: Optional[float] = None
+
+    # Gedetailleerde objecten
+    bouwvlak: Optional[BouwvlakResponse] = None
+    functieaanduidingen: List[str] = []
+    bouwaanduidingen: List[str] = []
+    maatvoeringen: List[MaatvoeringResponse] = []
+
+    # Regelteksten
+    regels_samenvatting: Optional[str] = None
+    regels_url: Optional[str] = None
+
+    # Toekomstige ontwikkelingen
+    ontwerp_plannen: List[OntwerpPlanResponse] = []
+
+    # Links & indicators
+    link_plan: str
+    uitbreidings_indicator: Optional[str] = None
+    uitbreidings_toelichting: Optional[str] = None
+
+    # Meta
+    error: Optional[str] = None
+
+
+# --- Uitbreidingsmogelijkheden logica ---
+
+
+def _bereken_uitbreidings_indicator(
+    bestemming: str,
+    heeft_bouwvlak: bool,
+    max_bebouwingspercentage: Optional[int],
+    max_bouwhoogte: Optional[float],
+    bouwaanduidingen: List[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Schat uitbreidingsmogelijkheden in op basis van bestemmingsplandata.
+
+    Returns:
+        (indicator, toelichting) — indicator is "gunstig", "beperkt", of "ongunstig"
+    """
+    score = 0
+    redenen: List[str] = []
+
+    # Bestemming
+    bestemming_lower = bestemming.lower()
+    if "wonen" in bestemming_lower:
+        score += 2
+    elif "gemengd" in bestemming_lower or "centrum" in bestemming_lower:
+        score += 1
+    else:
+        redenen.append(f"bestemming '{bestemming}' beperkt woninguitbreiding")
+
+    # Bouwvlak
+    if heeft_bouwvlak:
+        score += 1
+        redenen.append("bouwvlak aanwezig")
+    else:
+        redenen.append("geen bouwvlak gevonden")
+
+    # Bebouwingspercentage
+    if max_bebouwingspercentage is not None:
+        if max_bebouwingspercentage >= 60:
+            score += 2
+            redenen.append(f"bebouwing tot {max_bebouwingspercentage}% toegestaan")
+        elif max_bebouwingspercentage >= 40:
+            score += 1
+            redenen.append(f"bebouwing tot {max_bebouwingspercentage}%")
+        else:
+            redenen.append(f"bebouwing beperkt tot {max_bebouwingspercentage}%")
+
+    # Bouwhoogte
+    if max_bouwhoogte is not None:
+        if max_bouwhoogte >= 9:  # ~3 bouwlagen
+            score += 2
+            redenen.append(f"bouwhoogte tot {max_bouwhoogte}m")
+        elif max_bouwhoogte >= 6:  # ~2 bouwlagen
+            score += 1
+            redenen.append(f"bouwhoogte tot {max_bouwhoogte}m")
+        else:
+            redenen.append(f"bouwhoogte beperkt tot {max_bouwhoogte}m")
+
+    # Bouwaanduidingen
+    ba_lower = [b.lower() for b in bouwaanduidingen]
+    if any("bijgebouw" in b for b in ba_lower):
+        score += 1
+        redenen.append("bijgebouwen toegestaan")
+
+    # Bepaal indicator
+    if score >= 5:
+        indicator = "gunstig"
+    elif score >= 3:
+        indicator = "beperkt"
+    else:
+        indicator = "ongunstig"
+
+    toelichting = "; ".join(redenen) if redenen else None
+    return indicator, toelichting
+
+
+# --- Collector singleton ---
+
+
+_collector = None
+
+
+def _get_collector():
+    global _collector
+    if _collector is None:
+        _collector = create_bestemmingsplan_collector()
+    return _collector
+
+
+# --- Endpoints ---
+
+
+@router.get("", response_model=BestemmingsplanResponse)
+def get_bestemmingsplan(
+    lat: float = Query(..., description="Breedtegraad (WGS84)"),
+    lng: float = Query(..., description="Lengtegraad (WGS84)"),
+):
+    """Bestemmingsplan informatie voor een locatie."""
+    collector = _get_collector()
+    info = collector.get_bestemmingsplan(lat, lng)
+
+    # Bereken uitbreidingsindicator
+    indicator, toelichting = _bereken_uitbreidings_indicator(
+        bestemming=info.bestemming,
+        heeft_bouwvlak=info.bouwvlak is not None,
+        max_bebouwingspercentage=info.max_bebouwingspercentage,
+        max_bouwhoogte=info.max_bouwhoogte,
+        bouwaanduidingen=info.bouwaanduidingen,
+    )
+
+    # Bouw response
+    bouwvlak_resp = None
+    if info.bouwvlak:
+        bouwvlak_resp = BouwvlakResponse(
+            geometrie=info.bouwvlak.geometrie,
+            maatvoeringen=[
+                MaatvoeringResponse(
+                    naam=m.naam,
+                    waarde=m.waarde,
+                    eenheid=m.eenheid,
+                    waarde_type=m.waarde_type,
+                )
+                for m in info.bouwvlak.maatvoeringen
+            ],
+        )
+
+    ontwerp_resp = [
+        OntwerpPlanResponse(**op) for op in info.ontwerp_plannen
+    ]
+
+    return BestemmingsplanResponse(
+        plan_naam=info.plan_naam,
+        plan_type=info.plan_type,
+        plan_status=info.plan_status,
+        datum_vaststelling=info.datum_vaststelling,
+        bestemming=info.bestemming,
+        bestemming_specifiek=info.bestemming_specifiek,
+        max_bouwhoogte=info.max_bouwhoogte,
+        max_goothoogte=info.max_goothoogte,
+        max_bebouwingspercentage=info.max_bebouwingspercentage,
+        max_inhoud=info.max_inhoud,
+        bouwvlak=bouwvlak_resp,
+        functieaanduidingen=info.functieaanduidingen,
+        bouwaanduidingen=info.bouwaanduidingen,
+        maatvoeringen=[
+            MaatvoeringResponse(
+                naam=m.naam,
+                waarde=m.waarde,
+                eenheid=m.eenheid,
+                waarde_type=m.waarde_type,
+            )
+            for m in info.maatvoeringen
+        ],
+        regels_samenvatting=info.regels_samenvatting,
+        regels_url=info.regels_url,
+        ontwerp_plannen=ontwerp_resp,
+        link_plan=info.link_plan,
+        uitbreidings_indicator=indicator,
+        uitbreidings_toelichting=toelichting,
+        error=info.error,
+    )
+
+
+@router.get("/woning/{woning_id}", response_model=BestemmingsplanResponse)
+def get_woning_bestemmingsplan(
+    woning_id: int,
+    db: Session = Depends(get_db),
+):
+    """Bestemmingsplan informatie voor een woning (op basis van coordinaten)."""
+    woning = db.query(Woning).filter(Woning.id == woning_id).first()
+    if not woning:
+        return BestemmingsplanResponse(
+            plan_naam="",
+            plan_type="",
+            plan_status="",
+            bestemming="",
+            link_plan="",
+            error=f"Woning {woning_id} niet gevonden",
+        )
+
+    if not woning.latitude or not woning.longitude:
+        return BestemmingsplanResponse(
+            plan_naam="",
+            plan_type="",
+            plan_status="",
+            bestemming="",
+            link_plan="",
+            error="Woning heeft geen coordinaten",
+        )
+
+    return get_bestemmingsplan(lat=woning.latitude, lng=woning.longitude)
+
+
+# --- Omgevingsanalyse Response Models ---
+
+
+class BurenBouwinfoResponse(BaseModel):
+    bestemming: str
+    max_bouwhoogte: Optional[float] = None
+    max_goothoogte: Optional[float] = None
+    max_bebouwingspercentage: Optional[int] = None
+
+
+class OmgevingsAnalyseResponse(BaseModel):
+    """GeoJSON FeatureCollection met bestemmingsvlakken + metadata."""
+
+    type: str = "FeatureCollection"
+    features: List[Dict[str, Any]] = []
+    statistieken: Dict[str, int] = {}
+    statistieken_pct: Dict[str, float] = {}
+    ontwerp_plannen: List[OntwerpPlanResponse] = []
+    buren_bouwinfo: List[BurenBouwinfoResponse] = []
+    center: List[float] = []
+    radius_m: float = 500
+    error: Optional[str] = None
+
+
+# --- Omgevingsanalyse Endpoints ---
+
+
+@router.get("/omgeving", response_model=OmgevingsAnalyseResponse)
+def get_omgevingsanalyse(
+    lat: float = Query(..., description="Breedtegraad (WGS84)"),
+    lng: float = Query(..., description="Lengtegraad (WGS84)"),
+    radius_m: float = Query(500, ge=100, le=1000, description="Zoekradius in meters"),
+):
+    """Bestemmingen, ontwerp-plannen en buren-info in de omgeving van een locatie."""
+    collector = _get_collector()
+    analyse = collector.get_omgevingsanalyse(lat, lng, radius_m)
+
+    if analyse.error:
+        return OmgevingsAnalyseResponse(
+            center=[lat, lng],
+            radius_m=radius_m,
+            error=analyse.error,
+        )
+
+    # Bouw GeoJSON features
+    features: List[Dict[str, Any]] = []
+    for b in analyse.bestemmingen:
+        if not b.geometrie:
+            continue
+        features.append({
+            "type": "Feature",
+            "geometry": b.geometrie,
+            "properties": {
+                "naam": b.naam,
+                "categorie": b.categorie,
+                "plan_naam": b.plan_naam or "",
+            },
+        })
+
+    ontwerp_resp = [
+        OntwerpPlanResponse(**op) for op in analyse.ontwerp_plannen
+    ]
+
+    buren_resp = [
+        BurenBouwinfoResponse(
+            bestemming=bi.bestemming,
+            max_bouwhoogte=bi.max_bouwhoogte,
+            max_goothoogte=bi.max_goothoogte,
+            max_bebouwingspercentage=bi.max_bebouwingspercentage,
+        )
+        for bi in analyse.buren_bouwinfo
+    ]
+
+    return OmgevingsAnalyseResponse(
+        type="FeatureCollection",
+        features=features,
+        statistieken=analyse.statistieken,
+        statistieken_pct=analyse.statistieken_pct,
+        ontwerp_plannen=ontwerp_resp,
+        buren_bouwinfo=buren_resp,
+        center=[lat, lng],
+        radius_m=radius_m,
+    )
+
+
+@router.get("/woning/{woning_id}/omgeving", response_model=OmgevingsAnalyseResponse)
+def get_woning_omgevingsanalyse(
+    woning_id: int,
+    radius_m: float = Query(500, ge=100, le=1000),
+    db: Session = Depends(get_db),
+):
+    """Omgevingsanalyse voor een woning."""
+    woning = db.query(Woning).filter(Woning.id == woning_id).first()
+    if not woning:
+        return OmgevingsAnalyseResponse(error=f"Woning {woning_id} niet gevonden")
+
+    if not woning.latitude or not woning.longitude:
+        return OmgevingsAnalyseResponse(error="Woning heeft geen coordinaten")
+
+    return get_omgevingsanalyse(
+        lat=woning.latitude, lng=woning.longitude, radius_m=radius_m
+    )

--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -283,6 +283,10 @@ class EnhancedWaardebepalingResponse(BaseModel):
     # Funda listing
     funda_listing: Optional[FundaListing] = None
 
+    # Coordinaten (voor frontend componenten)
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+
     # Saved woning reference
     woning_id: Optional[int] = None
 
@@ -1464,5 +1468,7 @@ def bereken_waarde_voor_adres(
         data_bronnen=data_bronnen,
         monument=monument_result,
         funda_listing=funda_listing_data,
+        latitude=geo["lat"] if geo else None,
+        longitude=geo["lng"] if geo else None,
         woning_id=saved_woning_id,
     )

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -100,6 +100,15 @@ from collectors.pfas_bodemkaart_collector import (
     BodemkaartResult,
     create_pfas_bodemkaart_collector,
 )
+from collectors.bestemmingsplan_collector import (
+    BestemmingsplanCollector,
+    BestemmingsplanInfo,
+    Maatvoering,
+    OmgevingsAnalyse,
+    OmgevingsBestemming,
+    BurenBouwinfo,
+    create_bestemmingsplan_collector,
+)
 from collectors.funda_collector import (
     FundaCollector,
     PropertyListing,
@@ -197,6 +206,14 @@ __all__ = [
     "PFASBodemkaartCollector",
     "BodemkaartResult",
     "create_pfas_bodemkaart_collector",
+    # Bestemmingsplan (DSO)
+    "BestemmingsplanCollector",
+    "BestemmingsplanInfo",
+    "Maatvoering",
+    "OmgevingsAnalyse",
+    "OmgevingsBestemming",
+    "BurenBouwinfo",
+    "create_bestemmingsplan_collector",
     # Funda
     "FundaCollector",
     "PropertyListing",

--- a/backend/collectors/bestemmingsplan_collector.py
+++ b/backend/collectors/bestemmingsplan_collector.py
@@ -1,0 +1,1010 @@
+"""
+Bestemmingsplan Collector.
+
+Haalt bestemmingsplan/omgevingsplan informatie op via de Ruimtelijke Plannen API v4
+van het Digitaal Stelsel Omgevingswet (DSO).
+
+Bron: https://ruimte.omgevingswet.overheid.nl/ruimtelijke-plannen/api/opvragen/v4
+Vereist: DSO_API_KEY environment variable
+
+Overgangsperiode (2024-2032): zowel oude bestemmingsplannen (IMRO) als nieuwe
+omgevingsplannen worden ondersteund via dezelfde API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import math
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://ruimte.omgevingswet.overheid.nl/ruimtelijke-plannen/api/opvragen/v4"
+
+CACHE_DIR = Path(__file__).parent.parent.parent / "data" / "cache" / "bestemmingsplan"
+CACHE_DIR_OMGEVING = CACHE_DIR / "omgeving"
+CACHE_DURATION_SECONDS = 30 * 24 * 60 * 60  # 30 dagen
+
+# Bekende plantypen (prioriteit: hoger = relevanter)
+PLAN_TYPE_PRIORITY = {
+    "bestemmingsplan": 10,
+    "omgevingsplan": 10,
+    "inpassingsplan": 8,
+    "wijzigingsplan": 7,
+    "uitwerkingsplan": 7,
+    "beheersverordening": 6,
+}
+
+# Bekende maatvoering-namen en hun normalisatie
+MAATVOERING_PATTERNS = {
+    "max_bouwhoogte": re.compile(r"maxi\w*\s+bouwhoogte", re.IGNORECASE),
+    "max_goothoogte": re.compile(r"maxi\w*\s+goothoogte", re.IGNORECASE),
+    "max_bebouwingspercentage": re.compile(r"maxi\w*\s+bebouwings\s*percentage", re.IGNORECASE),
+    "max_inhoud": re.compile(r"maxi\w*\s+inhoud", re.IGNORECASE),
+    "max_oppervlakte": re.compile(r"maxi\w*\s+oppervlakte", re.IGNORECASE),
+    "max_dakhelling": re.compile(r"maxi\w*\s+dakhelling", re.IGNORECASE),
+    "min_dakhelling": re.compile(r"mini\w*\s+dakhelling", re.IGNORECASE),
+    "max_bouwdiepte": re.compile(r"maxi\w*\s+bouwdiepte", re.IGNORECASE),
+    "max_breedte": re.compile(r"maxi\w*\s+breedte", re.IGNORECASE),
+    "min_oppervlakte": re.compile(r"mini\w*\s+oppervlakte", re.IGNORECASE),
+}
+
+
+# Bestemming categorisatie — substring matching (case-insensitive)
+BESTEMMING_CATEGORIES: Dict[str, List[str]] = {
+    "wonen": ["wonen", "woondoeleinden"],
+    "groen": ["groen", "groenvoorzieningen", "natuur", "bos"],
+    "verkeer": ["verkeer", "verkeers", "weg", "parkeren"],
+    "water": ["water"],
+    "bedrijven": ["bedrijv", "bedrijfsdoeleinden"],
+    "maatschappelijk": ["maatschappelijk", "onderwijs", "gezondheidszorg"],
+    "detailhandel": ["detailhandel", "winkel"],
+    "horeca": ["horeca"],
+    "recreatie": ["recreat", "sport"],
+    "gemengd": ["gemengd", "centrum"],
+    "agrarisch": ["agrarisch"],
+    "tuin": ["tuin"],
+}
+
+
+def _categorize_bestemming(naam: str) -> str:
+    """Categoriseer een bestemmingsnaam naar een standaard categorie."""
+    naam_lower = naam.lower()
+    for categorie, keywords in BESTEMMING_CATEGORIES.items():
+        if any(kw in naam_lower for kw in keywords):
+            return categorie
+    return "overig"
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Eenvoudige XHTML → platte tekst converter."""
+
+    def __init__(self):
+        super().__init__()
+        self._parts: List[str] = []
+
+    def handle_data(self, data: str) -> None:
+        self._parts.append(data)
+
+    def get_text(self) -> str:
+        return " ".join(self._parts)
+
+
+def _xhtml_to_text(xhtml: str) -> str:
+    """Strip XHTML tags en retourneer platte tekst."""
+    parser = _HTMLTextExtractor()
+    parser.feed(xhtml)
+    text = parser.get_text()
+    # Normaliseer whitespace
+    return re.sub(r"\s+", " ", text).strip()
+
+
+@dataclass
+class Maatvoering:
+    """Dimensionele bouwregel uit het bestemmingsplan."""
+
+    naam: str
+    waarde: str
+    eenheid: Optional[str] = None
+    waarde_type: Optional[str] = None  # "exact", "maximaal", "minimaal"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Maatvoering":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class Bouwvlak:
+    """Bouwvlak geometrie en regels."""
+
+    geometrie: Optional[Dict] = None  # GeoJSON
+    maatvoeringen: List[Maatvoering] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "geometrie": self.geometrie,
+            "maatvoeringen": [m.to_dict() for m in self.maatvoeringen],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Bouwvlak":
+        return cls(
+            geometrie=data.get("geometrie"),
+            maatvoeringen=[Maatvoering.from_dict(m) for m in data.get("maatvoeringen", [])],
+        )
+
+
+@dataclass
+class BestemmingsplanInfo:
+    """Volledige bestemmingsplan informatie voor een locatie."""
+
+    # Plan metadata
+    plan_naam: str
+    plan_id: str
+    plan_type: str
+    plan_status: str
+    datum_vaststelling: Optional[str] = None
+
+    # Bestemming
+    bestemming: str = "Onbekend"
+    bestemming_specifiek: Optional[str] = None
+
+    # Bouwregels (uit maatvoeringen)
+    max_bouwhoogte: Optional[float] = None
+    max_goothoogte: Optional[float] = None
+    max_bebouwingspercentage: Optional[int] = None
+    max_inhoud: Optional[float] = None
+
+    # Gedetailleerde objecten
+    bouwvlak: Optional[Bouwvlak] = None
+    functieaanduidingen: List[str] = field(default_factory=list)
+    bouwaanduidingen: List[str] = field(default_factory=list)
+    maatvoeringen: List[Maatvoering] = field(default_factory=list)
+
+    # Regelteksten
+    regels_samenvatting: Optional[str] = None
+    regels_url: Optional[str] = None
+
+    # Toekomstige ontwikkelingen
+    ontwerp_plannen: List[Dict] = field(default_factory=list)
+
+    # Link
+    link_plan: str = ""
+
+    # Meta
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = {}
+        for k, v in self.__dict__.items():
+            if v is None:
+                continue
+            if k == "bouwvlak" and v is not None:
+                d[k] = v.to_dict()
+            elif k == "maatvoeringen":
+                d[k] = [m.to_dict() for m in v]
+            else:
+                d[k] = v
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BestemmingsplanInfo":
+        kw = {}
+        for k, v in data.items():
+            if k not in cls.__dataclass_fields__:
+                continue
+            if k == "bouwvlak" and isinstance(v, dict):
+                kw[k] = Bouwvlak.from_dict(v)
+            elif k == "maatvoeringen" and isinstance(v, list):
+                kw[k] = [Maatvoering.from_dict(m) for m in v]
+            else:
+                kw[k] = v
+        return cls(**kw)
+
+
+@dataclass
+class OmgevingsBestemming:
+    """Een bestemmingsvlak in de omgeving."""
+
+    naam: str
+    categorie: str
+    geometrie: Optional[Dict] = None
+    plan_naam: Optional[str] = None
+    plan_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OmgevingsBestemming":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class BurenBouwinfo:
+    """Bouwmogelijkheden van een naburig bestemmingsvlak."""
+
+    bestemming: str
+    max_bouwhoogte: Optional[float] = None
+    max_goothoogte: Optional[float] = None
+    max_bebouwingspercentage: Optional[int] = None
+    geometrie: Optional[Dict] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BurenBouwinfo":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class OmgevingsAnalyse:
+    """Analyse van bestemmingen in de omgeving van een locatie."""
+
+    bestemmingen: List[OmgevingsBestemming] = field(default_factory=list)
+    statistieken: Dict[str, int] = field(default_factory=dict)
+    statistieken_pct: Dict[str, float] = field(default_factory=dict)
+    ontwerp_plannen: List[Dict] = field(default_factory=list)
+    buren_bouwinfo: List[BurenBouwinfo] = field(default_factory=list)
+    center_lat: float = 0.0
+    center_lng: float = 0.0
+    radius_m: float = 500.0
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "center_lat": self.center_lat,
+            "center_lng": self.center_lng,
+            "radius_m": self.radius_m,
+            "statistieken": self.statistieken,
+            "statistieken_pct": self.statistieken_pct,
+            "ontwerp_plannen": self.ontwerp_plannen,
+            "bestemmingen": [b.to_dict() for b in self.bestemmingen],
+            "buren_bouwinfo": [b.to_dict() for b in self.buren_bouwinfo],
+        }
+        if self.error:
+            d["error"] = self.error
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OmgevingsAnalyse":
+        return cls(
+            bestemmingen=[OmgevingsBestemming.from_dict(b) for b in data.get("bestemmingen", [])],
+            statistieken=data.get("statistieken", {}),
+            statistieken_pct=data.get("statistieken_pct", {}),
+            ontwerp_plannen=data.get("ontwerp_plannen", []),
+            buren_bouwinfo=[BurenBouwinfo.from_dict(b) for b in data.get("buren_bouwinfo", [])],
+            center_lat=data.get("center_lat", 0),
+            center_lng=data.get("center_lng", 0),
+            radius_m=data.get("radius_m", 500),
+            error=data.get("error"),
+        )
+
+
+@dataclass
+class BestemmingsplanCollector:
+    """
+    Collector voor bestemmingsplannen via de Ruimtelijke Plannen API v4 (DSO).
+
+    Zoekt op basis van coordinaten (WGS84) het geldende bestemmingsplan,
+    inclusief bestemming, bouwregels, maatvoeringen en regelteksten.
+    """
+
+    min_delay: float = 1.0
+    max_delay: float = 2.0
+    cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
+    cache_days: int = 30
+    session: Optional[requests.Session] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if self.session is None:
+            self.session = requests.Session()
+            self.session.headers.update({
+                "Accept": "application/hal+json",
+                "Content-Type": "application/json",
+                "Content-Crs": "epsg:4326",
+                "Accept-Crs": "epsg:4326",
+            })
+            api_key = os.environ.get("DSO_API_KEY", "")
+            if api_key:
+                self.session.headers["X-Api-Key"] = api_key
+
+    def _rate_limit(self) -> None:
+        import random
+        elapsed = time.time() - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.time()
+
+    def _cache_key(self, lat: float, lng: float) -> str:
+        raw = f"{lat:.5f},{lng:.5f}"
+        return hashlib.md5(raw.encode()).hexdigest()
+
+    def _load_from_cache(self, key: str) -> Optional[Dict]:
+        cache_file = self.cache_dir / f"{key}.json"
+        if not cache_file.exists():
+            return None
+        try:
+            with cache_file.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            cached_at = data.get("_cached_at", 0)
+            if time.time() - cached_at > self.cache_days * 86400:
+                return None
+            return data
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _save_to_cache(self, key: str, data: Dict) -> None:
+        cache_file = self.cache_dir / f"{key}.json"
+        data["_cached_at"] = time.time()
+        try:
+            with cache_file.open("w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+        except OSError as e:
+            logger.warning("Cache write failed: %s", e)
+
+    def _api_call(self, method: str, path: str, **kwargs) -> Optional[Dict]:
+        """Voer een API-call uit met rate limiting en error handling."""
+        api_key = os.environ.get("DSO_API_KEY", "")
+        if not api_key:
+            logger.warning("DSO_API_KEY niet geconfigureerd")
+            return None
+
+        self._rate_limit()
+        url = f"{API_BASE}{path}"
+        try:
+            if method == "POST":
+                resp = self.session.post(url, **kwargs)
+            else:
+                resp = self.session.get(url, **kwargs)
+
+            if resp.status_code == 429:
+                logger.warning("Rate limit bereikt voor DSO API, wacht 10s")
+                time.sleep(10)
+                return self._api_call(method, path, **kwargs)
+            if resp.status_code == 401:
+                logger.error("DSO API key ongeldig of verlopen")
+                return None
+            if resp.status_code >= 400:
+                logger.warning("DSO API error %d: %s", resp.status_code, resp.text[:200])
+                return None
+
+            return resp.json()
+        except requests.RequestException as e:
+            logger.error("DSO API request failed: %s", e)
+            return None
+
+    def _geo_body(self, lat: float, lng: float) -> Dict:
+        """GeoJSON punt voor _zoek endpoints."""
+        return {
+            "_geo": {
+                "intersects": {
+                    "type": "Point",
+                    "coordinates": [lng, lat],  # GeoJSON: [lng, lat]
+                }
+            }
+        }
+
+    def _find_plan(self, lat: float, lng: float) -> Optional[Dict]:
+        """Zoek het meest relevante geldende plan voor een locatie."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/plannen/_zoek", json=body, params={
+            "pageSize": 20,
+            "expand": "bbox",
+        })
+        if not data:
+            return None
+
+        plannen = data.get("_embedded", {}).get("plannen", [])
+        if not plannen:
+            return None
+
+        # Filter en sorteer op relevantie
+        scored: List[Tuple[int, Dict]] = []
+        for plan in plannen:
+            plan_type = plan.get("planType", "").lower()
+            status = plan.get("planStatus", "").lower()
+
+            # Skip ontwerp-plannen (die halen we apart op)
+            if "ontwerp" in status:
+                continue
+
+            priority = PLAN_TYPE_PRIORITY.get(plan_type, 1)
+            # Vastgestelde plannen krijgen bonus
+            if "vastgesteld" in status or "onherroepelijk" in status:
+                priority += 5
+            scored.append((priority, plan))
+
+        if not scored:
+            return None
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return scored[0][1]
+
+    def _find_ontwerp_plannen(self, lat: float, lng: float) -> List[Dict]:
+        """Zoek ontwerp-plannen voor een locatie (toekomstige ontwikkelingen)."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/plannen/_zoek", json=body, params={
+            "pageSize": 10,
+        })
+        if not data:
+            return []
+
+        plannen = data.get("_embedded", {}).get("plannen", [])
+        ontwerp = []
+        for plan in plannen:
+            status = plan.get("planStatus", "").lower()
+            if "ontwerp" in status:
+                ontwerp.append({
+                    "naam": plan.get("naam", ""),
+                    "type": plan.get("planType", ""),
+                    "status": plan.get("planStatus", ""),
+                    "datum": plan.get("planstatusdatum", ""),
+                    "id": plan.get("id", ""),
+                })
+        return ontwerp
+
+    def _find_bestemmingsvlakken(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
+        """Zoek bestemmingsvlakken voor een locatie binnen een plan."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/bestemmingsvlakken/_zoek", json=body, params={
+            "planId": plan_id,
+            "expand": "geometrie",
+            "pageSize": 10,
+        })
+        if not data:
+            return []
+        return data.get("_embedded", {}).get("bestemmingsvlakken", [])
+
+    def _find_bouwvlakken(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
+        """Zoek bouwvlakken voor een locatie binnen een plan."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/bouwvlakken/_zoek", json=body, params={
+            "planId": plan_id,
+            "expand": "geometrie",
+            "pageSize": 10,
+        })
+        if not data:
+            return []
+        return data.get("_embedded", {}).get("bouwvlakken", [])
+
+    def _find_maatvoeringen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
+        """Zoek maatvoeringen (bouwhoogte, bebouwingspercentage, etc.)."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/maatvoeringen/_zoek", json=body, params={
+            "planId": plan_id,
+            "pageSize": 50,
+        })
+        if not data:
+            return []
+        return data.get("_embedded", {}).get("maatvoeringen", [])
+
+    def _find_functieaanduidingen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
+        """Zoek functieaanduidingen voor een locatie."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/functieaanduidingen/_zoek", json=body, params={
+            "planId": plan_id,
+            "pageSize": 20,
+        })
+        if not data:
+            return []
+        return data.get("_embedded", {}).get("functieaanduidingen", [])
+
+    def _find_bouwaanduidingen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
+        """Zoek bouwaanduidingen voor een locatie."""
+        body = self._geo_body(lat, lng)
+        data = self._api_call("POST", "/bouwaanduidingen/_zoek", json=body, params={
+            "planId": plan_id,
+            "pageSize": 20,
+        })
+        if not data:
+            return []
+        return data.get("_embedded", {}).get("bouwaanduidingen", [])
+
+    def _get_plan_teksten(self, plan_id: str) -> Optional[str]:
+        """Haal regelteksten op en extraheer bouwregel-samenvatting."""
+        data = self._api_call("GET", f"/plannen/{plan_id}/teksten", params={
+            "pageSize": 50,
+        })
+        if not data:
+            return None
+
+        teksten = data.get("_embedded", {}).get("teksten", [])
+        relevant_parts = []
+        keywords = [
+            "bouwhoogte", "bebouwingspercentage", "bijgebouw",
+            "erfafscheiding", "goothoogte", "bouwvlak", "bouwregel",
+            "uitbreiding", "aan- en uitbouw", "aanbouw",
+        ]
+
+        for tekst in teksten:
+            titel = tekst.get("titel", "").lower()
+            inhoud = tekst.get("inhoud", "")
+            if not inhoud:
+                continue
+
+            plain = _xhtml_to_text(inhoud)
+
+            # Check of titel of inhoud relevant is
+            is_relevant = any(kw in titel for kw in keywords)
+            if not is_relevant:
+                is_relevant = any(kw in plain.lower() for kw in keywords)
+
+            if is_relevant and plain:
+                header = tekst.get("titel", "")
+                snippet = plain[:300]
+                if len(plain) > 300:
+                    snippet += "..."
+                relevant_parts.append(f"{header}: {snippet}" if header else snippet)
+
+        if not relevant_parts:
+            return None
+
+        samenvatting = " | ".join(relevant_parts)
+        if len(samenvatting) > 500:
+            samenvatting = samenvatting[:497] + "..."
+        return samenvatting
+
+    def _parse_maatvoeringen(self, raw_maatvoeringen: List[Dict]) -> Tuple[List[Maatvoering], Dict[str, float]]:
+        """Parse ruwe maatvoeringen naar gestructureerde objecten."""
+        parsed: List[Maatvoering] = []
+        extracted: Dict[str, float] = {}
+
+        for mv in raw_maatvoeringen:
+            naam = mv.get("naam", "")
+            # Maatvoeringen bevatten vaak een waardeType en waarden array
+            waarden = mv.get("maatvoeringInfo", [])
+            if not waarden:
+                # Probeer alternatieve structuur
+                waarde = mv.get("waarde", "")
+                if waarde:
+                    waarden = [{"waarde": waarde}]
+
+            for w in waarden:
+                waarde_str = str(w.get("waarde", ""))
+                eenheid = w.get("eenheid")
+                waarde_type = w.get("waardeType")
+
+                m = Maatvoering(
+                    naam=naam,
+                    waarde=waarde_str,
+                    eenheid=eenheid,
+                    waarde_type=waarde_type,
+                )
+                parsed.append(m)
+
+                # Probeer bekende waarden te extraheren
+                try:
+                    val = float(waarde_str.replace(",", "."))
+                except (ValueError, TypeError):
+                    continue
+
+                for key, pattern in MAATVOERING_PATTERNS.items():
+                    if pattern.search(naam):
+                        # Bewaar de hoogste/meest specifieke waarde
+                        if key not in extracted or val > extracted[key]:
+                            extracted[key] = val
+                        break
+
+        return parsed, extracted
+
+    def _geo_body_bbox(self, lat: float, lng: float, radius_m: float = 500) -> Dict:
+        """GeoJSON polygon (bbox) voor _zoek endpoints."""
+        lat_rad = math.radians(lat)
+        delta_lat = radius_m / 111_000
+        delta_lng = radius_m / (111_000 * math.cos(lat_rad))
+
+        min_lat = lat - delta_lat
+        max_lat = lat + delta_lat
+        min_lng = lng - delta_lng
+        max_lng = lng + delta_lng
+
+        return {
+            "_geo": {
+                "intersects": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [min_lng, min_lat],
+                        [max_lng, min_lat],
+                        [max_lng, max_lat],
+                        [min_lng, max_lat],
+                        [min_lng, min_lat],  # sluit ring
+                    ]]
+                }
+            }
+        }
+
+    def _paginated_api_call(
+        self, method: str, path: str, resource_key: str, max_pages: int = 3, **kwargs
+    ) -> List[Dict]:
+        """Voer een gepagineerde API-call uit en verzamel alle resultaten."""
+        all_results: List[Dict] = []
+        for page in range(1, max_pages + 1):
+            params = kwargs.pop("params", {})
+            params["page"] = page
+            kwargs["params"] = params
+
+            data = self._api_call(method, path, **kwargs)
+            if not data:
+                break
+
+            items = data.get("_embedded", {}).get(resource_key, [])
+            if not items:
+                break
+            all_results.extend(items)
+
+            # Stop als er geen volgende pagina is
+            links = data.get("_links", {})
+            if "next" not in links:
+                break
+
+        return all_results
+
+    def find_bestemmingsvlakken_area(
+        self, lat: float, lng: float, radius_m: float = 500
+    ) -> List[Dict]:
+        """Zoek alle bestemmingsvlakken in een gebied (bbox)."""
+        body = self._geo_body_bbox(lat, lng, radius_m)
+        return self._paginated_api_call(
+            "POST", "/bestemmingsvlakken/_zoek", "bestemmingsvlakken",
+            max_pages=3,
+            json=body,
+            params={"expand": "geometrie", "pageSize": 100},
+        )
+
+    def _find_ontwerp_plannen_area(
+        self, lat: float, lng: float, radius_m: float = 500
+    ) -> List[Dict]:
+        """Zoek ontwerp-plannen in een gebied."""
+        body = self._geo_body_bbox(lat, lng, radius_m)
+        data = self._api_call("POST", "/plannen/_zoek", json=body, params={
+            "pageSize": 20,
+        })
+        if not data:
+            return []
+
+        plannen = data.get("_embedded", {}).get("plannen", [])
+        ontwerp = []
+        for plan in plannen:
+            status = plan.get("planStatus", "").lower()
+            if "ontwerp" in status:
+                ontwerp.append({
+                    "naam": plan.get("naam", ""),
+                    "type": plan.get("planType", ""),
+                    "status": plan.get("planStatus", ""),
+                    "datum": plan.get("planstatusdatum", ""),
+                    "id": plan.get("id", ""),
+                })
+        return ontwerp
+
+    def find_buren_bouwmogelijkheden(
+        self, lat: float, lng: float, eigen_bestemming: str
+    ) -> List[BurenBouwinfo]:
+        """Zoek bouwmogelijkheden van naburige bestemmingsvlakken (50m radius)."""
+        # Zoek vlakken in directe omgeving
+        body = self._geo_body_bbox(lat, lng, radius_m=50)
+        vlakken = self._paginated_api_call(
+            "POST", "/bestemmingsvlakken/_zoek", "bestemmingsvlakken",
+            max_pages=1,
+            json=body,
+            params={"expand": "geometrie", "pageSize": 20},
+        )
+
+        # Filter op andere bestemmingen dan de eigen
+        eigen_lower = eigen_bestemming.lower()
+        buren_vlakken = [
+            v for v in vlakken
+            if v.get("naam", "").lower() != eigen_lower
+        ]
+
+        # Beperk tot max 3 unieke bestemmingen
+        seen: set = set()
+        buren: List[BurenBouwinfo] = []
+        for vlak in buren_vlakken:
+            naam = vlak.get("naam", "Onbekend")
+            if naam in seen:
+                continue
+            seen.add(naam)
+
+            # Probeer maatvoeringen op te halen voor dit vlak
+            plan_href = vlak.get("_links", {}).get("plan", {}).get("href", "")
+            plan_id = plan_href.rstrip("/").split("/")[-1] if plan_href else ""
+
+            extracted: Dict[str, float] = {}
+            if plan_id:
+                # Zoek maatvoeringen in de buurt binnen hetzelfde plan
+                mv_body = self._geo_body_bbox(lat, lng, radius_m=50)
+                mv_raw = self._paginated_api_call(
+                    "POST", "/maatvoeringen/_zoek", "maatvoeringen",
+                    max_pages=1,
+                    json=mv_body,
+                    params={"planId": plan_id, "pageSize": 20},
+                )
+                _, extracted = self._parse_maatvoeringen(mv_raw)
+
+            buren.append(BurenBouwinfo(
+                bestemming=naam,
+                max_bouwhoogte=extracted.get("max_bouwhoogte"),
+                max_goothoogte=extracted.get("max_goothoogte"),
+                max_bebouwingspercentage=(
+                    int(extracted["max_bebouwingspercentage"])
+                    if "max_bebouwingspercentage" in extracted
+                    else None
+                ),
+                geometrie=vlak.get("geometrie"),
+            ))
+
+            if len(buren) >= 3:
+                break
+
+        return buren
+
+    def get_omgevingsanalyse(
+        self, lat: float, lng: float, radius_m: float = 500
+    ) -> OmgevingsAnalyse:
+        """
+        Analyseer bestemmingen in de omgeving van een locatie.
+
+        Returns:
+            OmgevingsAnalyse met bestemmingsvlakken, statistieken, ontwerp-plannen en buren-info
+        """
+        # Cache check (afgerond op 4 decimalen)
+        cache_dir = self.cache_dir / "omgeving"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_key = f"omgeving_{lat:.4f}_{lng:.4f}_{int(radius_m)}"
+        cache_file = cache_dir / f"{cache_key}.json"
+
+        if cache_file.exists():
+            try:
+                with cache_file.open("r", encoding="utf-8") as f:
+                    cached = json.load(f)
+                if time.time() - cached.get("_cached_at", 0) < self.cache_days * 86400:
+                    logger.info("Omgevingsanalyse uit cache voor %.4f,%.4f", lat, lng)
+                    return OmgevingsAnalyse.from_dict(cached)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        # Check API key
+        if not os.environ.get("DSO_API_KEY"):
+            return OmgevingsAnalyse(
+                center_lat=lat, center_lng=lng, radius_m=radius_m,
+                error="DSO_API_KEY niet geconfigureerd",
+            )
+
+        logger.info("Omgevingsanalyse ophalen voor %.4f,%.4f (radius %dm)", lat, lng, radius_m)
+
+        # 1. Alle bestemmingsvlakken in het gebied
+        raw_vlakken = self.find_bestemmingsvlakken_area(lat, lng, radius_m)
+
+        bestemmingen: List[OmgevingsBestemming] = []
+        for vlak in raw_vlakken:
+            naam = vlak.get("naam", vlak.get("type", "Onbekend"))
+            plan_ref = vlak.get("_links", {}).get("plan", {})
+            plan_naam = plan_ref.get("title", "")
+            plan_id = plan_ref.get("href", "").rstrip("/").split("/")[-1] if plan_ref.get("href") else ""
+
+            bestemmingen.append(OmgevingsBestemming(
+                naam=naam,
+                categorie=_categorize_bestemming(naam),
+                geometrie=vlak.get("geometrie"),
+                plan_naam=plan_naam,
+                plan_id=plan_id,
+            ))
+
+        # 2. Statistieken
+        cat_counts: Dict[str, int] = {}
+        for b in bestemmingen:
+            cat_counts[b.categorie] = cat_counts.get(b.categorie, 0) + 1
+        total = max(sum(cat_counts.values()), 1)
+        cat_pct = {k: round(v / total * 100, 1) for k, v in cat_counts.items()}
+
+        # Sorteer op percentage (dalend)
+        cat_counts = dict(sorted(cat_counts.items(), key=lambda x: x[1], reverse=True))
+        cat_pct = dict(sorted(cat_pct.items(), key=lambda x: x[1], reverse=True))
+
+        # 3. Ontwerp-plannen in de omgeving
+        ontwerp = self._find_ontwerp_plannen_area(lat, lng, radius_m)
+
+        # 4. Buren bouwmogelijkheden
+        # Eerst eigen bestemming bepalen
+        eigen_bestemming = ""
+        eigen_plan = self._find_plan(lat, lng)
+        if eigen_plan:
+            eigen_bv = self._find_bestemmingsvlakken(lat, lng, eigen_plan.get("id", ""))
+            if eigen_bv:
+                eigen_bestemming = eigen_bv[0].get("naam", "")
+
+        buren = []
+        if eigen_bestemming:
+            buren = self.find_buren_bouwmogelijkheden(lat, lng, eigen_bestemming)
+
+        result = OmgevingsAnalyse(
+            bestemmingen=bestemmingen,
+            statistieken=cat_counts,
+            statistieken_pct=cat_pct,
+            ontwerp_plannen=ontwerp,
+            buren_bouwinfo=buren,
+            center_lat=lat,
+            center_lng=lng,
+            radius_m=radius_m,
+        )
+
+        # Cache opslaan
+        try:
+            cache_data = result.to_dict()
+            cache_data["_cached_at"] = time.time()
+            with cache_file.open("w", encoding="utf-8") as f:
+                json.dump(cache_data, f, ensure_ascii=False, indent=2)
+        except OSError as e:
+            logger.warning("Omgevingsanalyse cache write failed: %s", e)
+
+        return result
+
+    def _build_plan_link(self, lat: float, lng: float) -> str:
+        """Genereer link naar Regels op de Kaart viewer."""
+        return (
+            f"https://omgevingswet.overheid.nl/regels-op-de-kaart"
+            f"?locatie-coordinaat={lat},{lng}"
+        )
+
+    def get_bestemmingsplan(self, lat: float, lng: float) -> BestemmingsplanInfo:
+        """
+        Haal bestemmingsplan informatie op voor een locatie.
+
+        Args:
+            lat: Breedtegraad (WGS84)
+            lng: Lengtegraad (WGS84)
+
+        Returns:
+            BestemmingsplanInfo met alle beschikbare data
+        """
+        # Check cache
+        cache_key = self._cache_key(lat, lng)
+        cached = self._load_from_cache(cache_key)
+        if cached:
+            logger.info("Bestemmingsplan uit cache voor %.5f,%.5f", lat, lng)
+            return BestemmingsplanInfo.from_dict(cached)
+
+        # Check API key
+        if not os.environ.get("DSO_API_KEY"):
+            return BestemmingsplanInfo(
+                plan_naam="",
+                plan_id="",
+                plan_type="",
+                plan_status="",
+                link_plan=self._build_plan_link(lat, lng),
+                error="DSO_API_KEY niet geconfigureerd",
+            )
+
+        logger.info("Bestemmingsplan ophalen voor %.5f,%.5f", lat, lng)
+
+        # 1. Zoek het geldende plan
+        plan = self._find_plan(lat, lng)
+        if not plan:
+            return BestemmingsplanInfo(
+                plan_naam="",
+                plan_id="",
+                plan_type="",
+                plan_status="",
+                link_plan=self._build_plan_link(lat, lng),
+                error="Geen bestemmingsplan gevonden voor deze locatie",
+            )
+
+        plan_id = plan.get("id", "")
+        plan_naam = plan.get("naam", "Onbekend plan")
+        plan_type = plan.get("planType", "")
+        plan_status = plan.get("planStatus", "")
+        datum = plan.get("planstatusdatum", "")
+
+        # 2. Bestemming ophalen
+        bestemming = "Onbekend"
+        bestemming_specifiek = None
+        bv_list = self._find_bestemmingsvlakken(lat, lng, plan_id)
+        if bv_list:
+            bv = bv_list[0]  # Meest specifieke
+            bestemming = bv.get("naam", bv.get("type", "Onbekend"))
+            bestemming_specifiek = bv.get("specificatie")
+
+        # 3. Bouwvlak
+        bouwvlak = None
+        bv_raw = self._find_bouwvlakken(lat, lng, plan_id)
+        if bv_raw:
+            bv_first = bv_raw[0]
+            bouwvlak = Bouwvlak(
+                geometrie=bv_first.get("geometrie"),
+            )
+
+        # 4. Maatvoeringen
+        mv_raw = self._find_maatvoeringen(lat, lng, plan_id)
+        maatvoeringen, extracted = self._parse_maatvoeringen(mv_raw)
+
+        # Koppel maatvoeringen aan bouwvlak indien aanwezig
+        if bouwvlak:
+            bouwvlak.maatvoeringen = maatvoeringen
+
+        # 5. Functieaanduidingen
+        fa_raw = self._find_functieaanduidingen(lat, lng, plan_id)
+        functieaanduidingen = [
+            fa.get("naam", fa.get("label", ""))
+            for fa in fa_raw
+            if fa.get("naam") or fa.get("label")
+        ]
+
+        # 6. Bouwaanduidingen
+        ba_raw = self._find_bouwaanduidingen(lat, lng, plan_id)
+        bouwaanduidingen = [
+            ba.get("naam", ba.get("label", ""))
+            for ba in ba_raw
+            if ba.get("naam") or ba.get("label")
+        ]
+
+        # 7. Regelteksten
+        regels_samenvatting = self._get_plan_teksten(plan_id)
+
+        # 8. Ontwerp-plannen (toekomstige ontwikkelingen)
+        ontwerp_plannen = self._find_ontwerp_plannen(lat, lng)
+
+        # 9. Regels URL
+        regels_url = None
+        links = plan.get("_links", {})
+        if "self" in links:
+            regels_url = links["self"].get("href")
+
+        # Bouw resultaat
+        info = BestemmingsplanInfo(
+            plan_naam=plan_naam,
+            plan_id=plan_id,
+            plan_type=plan_type,
+            plan_status=plan_status,
+            datum_vaststelling=datum,
+            bestemming=bestemming,
+            bestemming_specifiek=bestemming_specifiek,
+            max_bouwhoogte=extracted.get("max_bouwhoogte"),
+            max_goothoogte=extracted.get("max_goothoogte"),
+            max_bebouwingspercentage=(
+                int(extracted["max_bebouwingspercentage"])
+                if "max_bebouwingspercentage" in extracted
+                else None
+            ),
+            max_inhoud=extracted.get("max_inhoud"),
+            bouwvlak=bouwvlak,
+            functieaanduidingen=functieaanduidingen,
+            bouwaanduidingen=bouwaanduidingen,
+            maatvoeringen=maatvoeringen,
+            regels_samenvatting=regels_samenvatting,
+            regels_url=regels_url,
+            ontwerp_plannen=ontwerp_plannen,
+            link_plan=self._build_plan_link(lat, lng),
+        )
+
+        # Sla op in cache
+        self._save_to_cache(cache_key, info.to_dict())
+        return info
+
+
+def create_bestemmingsplan_collector(
+    cache_dir: Optional[Path] = None,
+) -> BestemmingsplanCollector:
+    """Factory function met default cache directory."""
+    if cache_dir is None:
+        project_root = Path(__file__).parent.parent.parent
+        cache_dir = project_root / "data" / "cache" / "bestemmingsplan"
+    return BestemmingsplanCollector(cache_dir=cache_dir)

--- a/backend/collectors/bestemmingsplan_collector.py
+++ b/backend/collectors/bestemmingsplan_collector.py
@@ -5,7 +5,7 @@ Haalt bestemmingsplan/omgevingsplan informatie op via de Ruimtelijke Plannen API
 van het Digitaal Stelsel Omgevingswet (DSO).
 
 Bron: https://ruimte.omgevingswet.overheid.nl/ruimtelijke-plannen/api/opvragen/v4
-Vereist: DSO_API_KEY environment variable
+Vereist: RUIMTELIJKE_PLANNEN_API_KEY environment variable
 
 Overgangsperiode (2024-2032): zowel oude bestemmingsplannen (IMRO) als nieuwe
 omgevingsplannen worden ondersteund via dezelfde API.
@@ -27,8 +27,30 @@ from typing import Any, Dict, List, Optional, Tuple
 import math
 
 import requests
+from pyproj import Transformer
 
 logger = logging.getLogger(__name__)
+
+# WGS84 (lat/lng) -> Rijksdriehoek (EPSG:28992) transformer
+_wgs84_to_rd = Transformer.from_crs("EPSG:4326", "EPSG:28992", always_xy=True)
+_rd_to_wgs84 = Transformer.from_crs("EPSG:28992", "EPSG:4326", always_xy=True)
+
+
+def _convert_geometry_rd_to_wgs84(geom: Optional[Dict]) -> Optional[Dict]:
+    """Converteer GeoJSON geometrie van RD (epsg:28992) naar WGS84 (epsg:4326)."""
+    if not geom:
+        return geom
+
+    def _convert_coords(coords):
+        if isinstance(coords[0], (int, float)):
+            lng, lat = _rd_to_wgs84.transform(coords[0], coords[1])
+            return [lng, lat]
+        return [_convert_coords(c) for c in coords]
+
+    return {
+        "type": geom["type"],
+        "coordinates": _convert_coords(geom["coordinates"]),
+    }
 
 API_BASE = "https://ruimte.omgevingswet.overheid.nl/ruimtelijke-plannen/api/opvragen/v4"
 
@@ -319,10 +341,10 @@ class BestemmingsplanCollector:
             self.session.headers.update({
                 "Accept": "application/hal+json",
                 "Content-Type": "application/json",
-                "Content-Crs": "epsg:4326",
-                "Accept-Crs": "epsg:4326",
+                "Content-Crs": "epsg:28992",
+                "Accept-Crs": "epsg:28992",
             })
-            api_key = os.environ.get("DSO_API_KEY", "")
+            api_key = os.environ.get("RUIMTELIJKE_PLANNEN_API_KEY", "")
             if api_key:
                 self.session.headers["X-Api-Key"] = api_key
 
@@ -363,9 +385,9 @@ class BestemmingsplanCollector:
 
     def _api_call(self, method: str, path: str, **kwargs) -> Optional[Dict]:
         """Voer een API-call uit met rate limiting en error handling."""
-        api_key = os.environ.get("DSO_API_KEY", "")
+        api_key = os.environ.get("RUIMTELIJKE_PLANNEN_API_KEY", "")
         if not api_key:
-            logger.warning("DSO_API_KEY niet geconfigureerd")
+            logger.warning("RUIMTELIJKE_PLANNEN_API_KEY niet geconfigureerd")
             return None
 
         self._rate_limit()
@@ -393,12 +415,13 @@ class BestemmingsplanCollector:
             return None
 
     def _geo_body(self, lat: float, lng: float) -> Dict:
-        """GeoJSON punt voor _zoek endpoints."""
+        """GeoJSON punt voor _zoek endpoints (converteert WGS84 naar RD)."""
+        x, y = _wgs84_to_rd.transform(lng, lat)
         return {
             "_geo": {
                 "intersects": {
                     "type": "Point",
-                    "coordinates": [lng, lat],  # GeoJSON: [lng, lat]
+                    "coordinates": [x, y],  # RD (epsg:28992)
                 }
             }
         }
@@ -406,32 +429,43 @@ class BestemmingsplanCollector:
     def _find_plan(self, lat: float, lng: float) -> Optional[Dict]:
         """Zoek het meest relevante geldende plan voor een locatie."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/plannen/_zoek", json=body, params={
-            "pageSize": 20,
-            "expand": "bbox",
-        })
-        if not data:
-            return None
 
-        plannen = data.get("_embedded", {}).get("plannen", [])
-        if not plannen:
-            return None
-
-        # Filter en sorteer op relevantie
+        # Doorloop meerdere pagina's om gemeentelijke plannen te vinden
         scored: List[Tuple[int, Dict]] = []
-        for plan in plannen:
-            plan_type = plan.get("planType", "").lower()
-            status = plan.get("planStatus", "").lower()
+        for page in range(1, 4):  # max 3 pagina's
+            data = self._api_call("POST", "/plannen/_zoek", json=body, params={
+                "pageSize": 50,
+                "page": page,
+            })
+            if not data:
+                break
 
-            # Skip ontwerp-plannen (die halen we apart op)
-            if "ontwerp" in status:
-                continue
+            plannen = data.get("_embedded", {}).get("plannen", [])
+            if not plannen:
+                break
 
-            priority = PLAN_TYPE_PRIORITY.get(plan_type, 1)
-            # Vastgestelde plannen krijgen bonus
-            if "vastgesteld" in status or "onherroepelijk" in status:
-                priority += 5
-            scored.append((priority, plan))
+            for plan in plannen:
+                plan_type = plan.get("type", "").lower()
+                status_info = plan.get("planstatusInfo", {})
+                status = status_info.get("planstatus", "").lower() if isinstance(status_info, dict) else ""
+
+                # Skip ontwerp-plannen (die halen we apart op)
+                if "ontwerp" in status:
+                    continue
+
+                priority = PLAN_TYPE_PRIORITY.get(plan_type, 1)
+                # Vastgestelde plannen krijgen bonus
+                if "vastgesteld" in status or "onherroepelijk" in status:
+                    priority += 5
+                # Paraplu/facet-herzieningen zijn overkoepelend, niet gebiedsgericht
+                naam = plan.get("naam", "").lower()
+                if "paraplu" in naam or "facet" in naam:
+                    priority -= 8
+                scored.append((priority, plan))
+
+            # Stop als we al een bestemmingsplan gevonden hebben
+            if any(s[0] >= 10 for s in scored):
+                break
 
         if not scored:
             return None
@@ -451,13 +485,14 @@ class BestemmingsplanCollector:
         plannen = data.get("_embedded", {}).get("plannen", [])
         ontwerp = []
         for plan in plannen:
-            status = plan.get("planStatus", "").lower()
+            status_info = plan.get("planstatusInfo", {})
+            status = status_info.get("planstatus", "").lower() if isinstance(status_info, dict) else ""
             if "ontwerp" in status:
                 ontwerp.append({
                     "naam": plan.get("naam", ""),
-                    "type": plan.get("planType", ""),
-                    "status": plan.get("planStatus", ""),
-                    "datum": plan.get("planstatusdatum", ""),
+                    "type": plan.get("type", ""),
+                    "status": status_info.get("planstatus", "") if isinstance(status_info, dict) else "",
+                    "datum": status_info.get("datum", "") if isinstance(status_info, dict) else "",
                     "id": plan.get("id", ""),
                 })
         return ontwerp
@@ -465,8 +500,7 @@ class BestemmingsplanCollector:
     def _find_bestemmingsvlakken(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
         """Zoek bestemmingsvlakken voor een locatie binnen een plan."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/bestemmingsvlakken/_zoek", json=body, params={
-            "planId": plan_id,
+        data = self._api_call("POST", f"/plannen/{plan_id}/bestemmingsvlakken/_zoek", json=body, params={
             "expand": "geometrie",
             "pageSize": 10,
         })
@@ -477,8 +511,7 @@ class BestemmingsplanCollector:
     def _find_bouwvlakken(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
         """Zoek bouwvlakken voor een locatie binnen een plan."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/bouwvlakken/_zoek", json=body, params={
-            "planId": plan_id,
+        data = self._api_call("POST", f"/plannen/{plan_id}/bouwvlakken/_zoek", json=body, params={
             "expand": "geometrie",
             "pageSize": 10,
         })
@@ -489,8 +522,7 @@ class BestemmingsplanCollector:
     def _find_maatvoeringen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
         """Zoek maatvoeringen (bouwhoogte, bebouwingspercentage, etc.)."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/maatvoeringen/_zoek", json=body, params={
-            "planId": plan_id,
+        data = self._api_call("POST", f"/plannen/{plan_id}/maatvoeringen/_zoek", json=body, params={
             "pageSize": 50,
         })
         if not data:
@@ -500,8 +532,7 @@ class BestemmingsplanCollector:
     def _find_functieaanduidingen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
         """Zoek functieaanduidingen voor een locatie."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/functieaanduidingen/_zoek", json=body, params={
-            "planId": plan_id,
+        data = self._api_call("POST", f"/plannen/{plan_id}/functieaanduidingen/_zoek", json=body, params={
             "pageSize": 20,
         })
         if not data:
@@ -511,8 +542,7 @@ class BestemmingsplanCollector:
     def _find_bouwaanduidingen(self, lat: float, lng: float, plan_id: str) -> List[Dict]:
         """Zoek bouwaanduidingen voor een locatie."""
         body = self._geo_body(lat, lng)
-        data = self._api_call("POST", "/bouwaanduidingen/_zoek", json=body, params={
-            "planId": plan_id,
+        data = self._api_call("POST", f"/plannen/{plan_id}/bouwaanduidingen/_zoek", json=body, params={
             "pageSize": 20,
         })
         if not data:
@@ -570,10 +600,11 @@ class BestemmingsplanCollector:
 
         for mv in raw_maatvoeringen:
             naam = mv.get("naam", "")
-            # Maatvoeringen bevatten vaak een waardeType en waarden array
-            waarden = mv.get("maatvoeringInfo", [])
+            # API geeft maatvoeringen terug met "omvang" array
+            waarden = mv.get("omvang", [])
             if not waarden:
-                # Probeer alternatieve structuur
+                waarden = mv.get("maatvoeringInfo", [])
+            if not waarden:
                 waarde = mv.get("waarde", "")
                 if waarde:
                     waarden = [{"waarde": waarde}]
@@ -607,26 +638,23 @@ class BestemmingsplanCollector:
         return parsed, extracted
 
     def _geo_body_bbox(self, lat: float, lng: float, radius_m: float = 500) -> Dict:
-        """GeoJSON polygon (bbox) voor _zoek endpoints."""
-        lat_rad = math.radians(lat)
-        delta_lat = radius_m / 111_000
-        delta_lng = radius_m / (111_000 * math.cos(lat_rad))
-
-        min_lat = lat - delta_lat
-        max_lat = lat + delta_lat
-        min_lng = lng - delta_lng
-        max_lng = lng + delta_lng
+        """GeoJSON polygon (bbox) voor _zoek endpoints (converteert WGS84 naar RD)."""
+        cx, cy = _wgs84_to_rd.transform(lng, lat)
+        min_x = cx - radius_m
+        max_x = cx + radius_m
+        min_y = cy - radius_m
+        max_y = cy + radius_m
 
         return {
             "_geo": {
                 "intersects": {
                     "type": "Polygon",
                     "coordinates": [[
-                        [min_lng, min_lat],
-                        [max_lng, min_lat],
-                        [max_lng, max_lat],
-                        [min_lng, max_lat],
-                        [min_lng, min_lat],  # sluit ring
+                        [min_x, min_y],
+                        [max_x, min_y],
+                        [max_x, max_y],
+                        [min_x, max_y],
+                        [min_x, min_y],  # sluit ring
                     ]]
                 }
             }
@@ -661,14 +689,38 @@ class BestemmingsplanCollector:
     def find_bestemmingsvlakken_area(
         self, lat: float, lng: float, radius_m: float = 500
     ) -> List[Dict]:
-        """Zoek alle bestemmingsvlakken in een gebied (bbox)."""
-        body = self._geo_body_bbox(lat, lng, radius_m)
-        return self._paginated_api_call(
-            "POST", "/bestemmingsvlakken/_zoek", "bestemmingsvlakken",
-            max_pages=3,
-            json=body,
-            params={"expand": "geometrie", "pageSize": 100},
-        )
+        """Zoek alle bestemmingsvlakken in een gebied (bbox) via plannen."""
+        body_bbox = self._geo_body_bbox(lat, lng, radius_m)
+
+        # Stap 1: vind plannen in het gebied
+        data = self._api_call("POST", "/plannen/_zoek", json=body_bbox, params={
+            "pageSize": 50,
+        })
+        if not data:
+            return []
+
+        plannen = data.get("_embedded", {}).get("plannen", [])
+        # Filter op relevante plantypes
+        plan_ids = []
+        for plan in plannen:
+            pt = plan.get("type", "").lower()
+            if pt in PLAN_TYPE_PRIORITY and "paraplu" not in plan.get("naam", "").lower():
+                plan_ids.append(plan.get("id", ""))
+
+        # Stap 2: haal bestemmingsvlakken per plan
+        all_vlakken: List[Dict] = []
+        for plan_id in plan_ids[:5]:  # max 5 plannen
+            vlakken = self._paginated_api_call(
+                "POST", f"/plannen/{plan_id}/bestemmingsvlakken/_zoek", "bestemmingsvlakken",
+                max_pages=2,
+                json=body_bbox,
+                params={"expand": "geometrie", "pageSize": 100},
+            )
+            all_vlakken.extend(vlakken)
+            if len(all_vlakken) >= 300:
+                break
+
+        return all_vlakken
 
     def _find_ontwerp_plannen_area(
         self, lat: float, lng: float, radius_m: float = 500
@@ -684,13 +736,14 @@ class BestemmingsplanCollector:
         plannen = data.get("_embedded", {}).get("plannen", [])
         ontwerp = []
         for plan in plannen:
-            status = plan.get("planStatus", "").lower()
+            status_info = plan.get("planstatusInfo", {})
+            status = status_info.get("planstatus", "").lower() if isinstance(status_info, dict) else ""
             if "ontwerp" in status:
                 ontwerp.append({
                     "naam": plan.get("naam", ""),
-                    "type": plan.get("planType", ""),
-                    "status": plan.get("planStatus", ""),
-                    "datum": plan.get("planstatusdatum", ""),
+                    "type": plan.get("type", ""),
+                    "status": status_info.get("planstatus", "") if isinstance(status_info, dict) else "",
+                    "datum": status_info.get("datum", "") if isinstance(status_info, dict) else "",
                     "id": plan.get("id", ""),
                 })
         return ontwerp
@@ -700,13 +753,8 @@ class BestemmingsplanCollector:
     ) -> List[BurenBouwinfo]:
         """Zoek bouwmogelijkheden van naburige bestemmingsvlakken (50m radius)."""
         # Zoek vlakken in directe omgeving
-        body = self._geo_body_bbox(lat, lng, radius_m=50)
-        vlakken = self._paginated_api_call(
-            "POST", "/bestemmingsvlakken/_zoek", "bestemmingsvlakken",
-            max_pages=1,
-            json=body,
-            params={"expand": "geometrie", "pageSize": 20},
-        )
+        # Zoek vlakken via plannen in directe omgeving
+        vlakken = self.find_bestemmingsvlakken_area(lat, lng, radius_m=50)
 
         # Filter op andere bestemmingen dan de eigen
         eigen_lower = eigen_bestemming.lower()
@@ -733,10 +781,10 @@ class BestemmingsplanCollector:
                 # Zoek maatvoeringen in de buurt binnen hetzelfde plan
                 mv_body = self._geo_body_bbox(lat, lng, radius_m=50)
                 mv_raw = self._paginated_api_call(
-                    "POST", "/maatvoeringen/_zoek", "maatvoeringen",
+                    "POST", f"/plannen/{plan_id}/maatvoeringen/_zoek", "maatvoeringen",
                     max_pages=1,
                     json=mv_body,
-                    params={"planId": plan_id, "pageSize": 20},
+                    params={"pageSize": 20},
                 )
                 _, extracted = self._parse_maatvoeringen(mv_raw)
 
@@ -749,7 +797,7 @@ class BestemmingsplanCollector:
                     if "max_bebouwingspercentage" in extracted
                     else None
                 ),
-                geometrie=vlak.get("geometrie"),
+                geometrie=_convert_geometry_rd_to_wgs84(vlak.get("geometrie")),
             ))
 
             if len(buren) >= 3:
@@ -783,10 +831,10 @@ class BestemmingsplanCollector:
                 pass
 
         # Check API key
-        if not os.environ.get("DSO_API_KEY"):
+        if not os.environ.get("RUIMTELIJKE_PLANNEN_API_KEY"):
             return OmgevingsAnalyse(
                 center_lat=lat, center_lng=lng, radius_m=radius_m,
-                error="DSO_API_KEY niet geconfigureerd",
+                error="RUIMTELIJKE_PLANNEN_API_KEY niet geconfigureerd",
             )
 
         logger.info("Omgevingsanalyse ophalen voor %.4f,%.4f (radius %dm)", lat, lng, radius_m)
@@ -804,7 +852,7 @@ class BestemmingsplanCollector:
             bestemmingen.append(OmgevingsBestemming(
                 naam=naam,
                 categorie=_categorize_bestemming(naam),
-                geometrie=vlak.get("geometrie"),
+                geometrie=_convert_geometry_rd_to_wgs84(vlak.get("geometrie")),
                 plan_naam=plan_naam,
                 plan_id=plan_id,
             ))
@@ -884,14 +932,14 @@ class BestemmingsplanCollector:
             return BestemmingsplanInfo.from_dict(cached)
 
         # Check API key
-        if not os.environ.get("DSO_API_KEY"):
+        if not os.environ.get("RUIMTELIJKE_PLANNEN_API_KEY"):
             return BestemmingsplanInfo(
                 plan_naam="",
                 plan_id="",
                 plan_type="",
                 plan_status="",
                 link_plan=self._build_plan_link(lat, lng),
-                error="DSO_API_KEY niet geconfigureerd",
+                error="RUIMTELIJKE_PLANNEN_API_KEY niet geconfigureerd",
             )
 
         logger.info("Bestemmingsplan ophalen voor %.5f,%.5f", lat, lng)
@@ -910,16 +958,19 @@ class BestemmingsplanCollector:
 
         plan_id = plan.get("id", "")
         plan_naam = plan.get("naam", "Onbekend plan")
-        plan_type = plan.get("planType", "")
-        plan_status = plan.get("planStatus", "")
-        datum = plan.get("planstatusdatum", "")
+        plan_type = plan.get("type", "")
+        status_info = plan.get("planstatusInfo", {})
+        plan_status = status_info.get("planstatus", "") if isinstance(status_info, dict) else ""
+        datum = status_info.get("datum", "") if isinstance(status_info, dict) else ""
 
         # 2. Bestemming ophalen
         bestemming = "Onbekend"
         bestemming_specifiek = None
         bv_list = self._find_bestemmingsvlakken(lat, lng, plan_id)
         if bv_list:
-            bv = bv_list[0]  # Meest specifieke
+            # Voorkeur: enkelbestemming > dubbelbestemming
+            enkel = [v for v in bv_list if v.get("type", "").lower() == "enkelbestemming"]
+            bv = enkel[0] if enkel else bv_list[0]
             bestemming = bv.get("naam", bv.get("type", "Onbekend"))
             bestemming_specifiek = bv.get("specificatie")
 
@@ -929,7 +980,7 @@ class BestemmingsplanCollector:
         if bv_raw:
             bv_first = bv_raw[0]
             bouwvlak = Bouwvlak(
-                geometrie=bv_first.get("geometrie"),
+                geometrie=_convert_geometry_rd_to_wgs84(bv_first.get("geometrie")),
             )
 
         # 4. Maatvoeringen

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ logging.basicConfig(
 env_path = Path(__file__).parent / ".env"
 load_dotenv(env_path)
 
-from api import buurten_router, woningen_router, waardebepaling_router, watchlist_router, markt_router, scholen_router, voorzieningen_router, postcode6_router, bereikbaarheid_router, milieu_router
+from api import buurten_router, woningen_router, waardebepaling_router, watchlist_router, markt_router, scholen_router, voorzieningen_router, postcode6_router, bereikbaarheid_router, milieu_router, bestemmingsplan_router
 from models.database import init_db
 from models import Buurt, Woning, WatchlistItem, Prijshistorie, School, Postcode6  # noqa: F401 - ensure models are loaded
 
@@ -83,6 +83,7 @@ app.include_router(voorzieningen_router)
 app.include_router(postcode6_router)
 app.include_router(bereikbaarheid_router)
 app.include_router(milieu_router)
+app.include_router(bestemmingsplan_router)
 
 
 @app.get("/")
@@ -102,6 +103,8 @@ def root():
             "bereikbaarheid": "/api/woningen/{id}/bereikbaarheid",
             "reistijd": "/api/locatie/reistijd",
             "postcode6": "/api/postcode6",
+            "milieu": "/api/milieu",
+            "bestemmingsplan": "/api/bestemmingsplan",
         },
     }
 

--- a/frontend/src/components/BestemmingsplanPanel.tsx
+++ b/frontend/src/components/BestemmingsplanPanel.tsx
@@ -1,0 +1,520 @@
+import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchBestemmingsplan,
+  fetchOmgevingsAnalyse,
+  BestemmingsplanResponse,
+  OmgevingsAnalyseResponse,
+  MaatvoeringItem,
+  BurenBouwinfoItem,
+} from '../services/api'
+
+interface BestemmingsplanPanelProps {
+  lat?: number | null
+  lng?: number | null
+  onOmgevingGeoJSON?: (data: OmgevingsAnalyseResponse | null) => void
+}
+
+const BESTEMMING_COLORS: Record<string, string> = {
+  wonen: 'bg-yellow-100 text-yellow-800',
+  gemengd: 'bg-purple-100 text-purple-800',
+  centrum: 'bg-orange-100 text-orange-800',
+  bedrijventerrein: 'bg-gray-100 text-gray-800',
+  groen: 'bg-green-100 text-green-800',
+  verkeer: 'bg-blue-100 text-blue-800',
+  maatschappelijk: 'bg-pink-100 text-pink-800',
+  recreatie: 'bg-teal-100 text-teal-800',
+}
+
+const CATEGORIE_KLEUREN: Record<string, string> = {
+  wonen: '#fbbf24',
+  groen: '#22c55e',
+  verkeer: '#9ca3af',
+  water: '#3b82f6',
+  bedrijven: '#8b5cf6',
+  maatschappelijk: '#ec4899',
+  detailhandel: '#f97316',
+  horeca: '#ef4444',
+  recreatie: '#14b8a6',
+  gemengd: '#a855f7',
+  agrarisch: '#84cc16',
+  tuin: '#86efac',
+  overig: '#d1d5db',
+}
+
+const CATEGORIE_LABELS: Record<string, string> = {
+  wonen: 'Wonen',
+  groen: 'Groen',
+  verkeer: 'Verkeer',
+  water: 'Water',
+  bedrijven: 'Bedrijven',
+  maatschappelijk: 'Maatschappelijk',
+  detailhandel: 'Detailhandel',
+  horeca: 'Horeca',
+  recreatie: 'Recreatie',
+  gemengd: 'Gemengd',
+  agrarisch: 'Agrarisch',
+  tuin: 'Tuin',
+  overig: 'Overig',
+}
+
+const INDICATOR_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  gunstig: { bg: 'bg-green-100', text: 'text-green-800', label: 'Gunstig' },
+  beperkt: { bg: 'bg-yellow-100', text: 'text-yellow-800', label: 'Beperkt' },
+  ongunstig: { bg: 'bg-red-100', text: 'text-red-800', label: 'Ongunstig' },
+}
+
+function getBestemmingColor(bestemming: string): string {
+  const lower = bestemming.toLowerCase()
+  for (const [key, color] of Object.entries(BESTEMMING_COLORS)) {
+    if (lower.includes(key)) return color
+  }
+  return 'bg-gray-100 text-gray-800'
+}
+
+function BestemmingBadge({ bestemming }: { bestemming: string }) {
+  return (
+    <span
+      className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${getBestemmingColor(bestemming)}`}
+    >
+      {bestemming}
+    </span>
+  )
+}
+
+function BouwregelsSection({ data }: { data: BestemmingsplanResponse }) {
+  const regels: { label: string; waarde: string }[] = []
+
+  if (data.max_bouwhoogte != null) {
+    regels.push({ label: 'Max. bouwhoogte', waarde: `${data.max_bouwhoogte} m` })
+  }
+  if (data.max_goothoogte != null) {
+    regels.push({ label: 'Max. goothoogte', waarde: `${data.max_goothoogte} m` })
+  }
+  if (data.max_bebouwingspercentage != null) {
+    regels.push({ label: 'Max. bebouwing', waarde: `${data.max_bebouwingspercentage}%` })
+  }
+  if (data.max_inhoud != null) {
+    regels.push({ label: 'Max. inhoud', waarde: `${data.max_inhoud} m\u00B3` })
+  }
+
+  const standaard = ['bouwhoogte', 'goothoogte', 'bebouwingspercentage', 'inhoud']
+  const overige = data.maatvoeringen.filter(
+    (m: MaatvoeringItem) => !standaard.some((s) => m.naam.toLowerCase().includes(s))
+  )
+  for (const m of overige) {
+    const eenheid = m.eenheid ? ` ${m.eenheid}` : ''
+    regels.push({ label: m.naam, waarde: `${m.waarde}${eenheid}` })
+  }
+
+  if (regels.length === 0) return null
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-700 mb-2">Bouwregels</h4>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+        {regels.map((r, i) => (
+          <div key={i} className="contents">
+            <span className="text-xs text-gray-500">{r.label}</span>
+            <span className="text-xs font-medium text-gray-900 text-right">{r.waarde}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function UitbreidingsIndicator({
+  indicator,
+  toelichting,
+}: {
+  indicator: string
+  toelichting?: string | null
+}) {
+  const style = INDICATOR_STYLES[indicator] || INDICATOR_STYLES.beperkt
+
+  return (
+    <div className={`${style.bg} rounded-lg p-3`}>
+      <div className="flex items-center gap-2">
+        <span className={`text-sm font-medium ${style.text}`}>
+          Uitbreidingsmogelijkheden: {style.label}
+        </span>
+      </div>
+      {toelichting && (
+        <p className={`text-xs ${style.text} mt-1 opacity-80`}>{toelichting}</p>
+      )}
+    </div>
+  )
+}
+
+function FunctiesSection({ items }: { items: string[] }) {
+  if (items.length === 0) return null
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-700 mb-1">Functieaanduidingen</h4>
+      <div className="flex flex-wrap gap-1">
+        {items.map((f, i) => (
+          <span
+            key={i}
+            className="inline-block px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded"
+          >
+            {f}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function BouwaanduidingenSection({ items }: { items: string[] }) {
+  if (items.length === 0) return null
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-700 mb-1">Bouwaanduidingen</h4>
+      <div className="flex flex-wrap gap-1">
+        {items.map((b, i) => (
+          <span
+            key={i}
+            className="inline-block px-2 py-0.5 bg-amber-50 text-amber-700 text-xs rounded"
+          >
+            {b}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RegelsSection({ samenvatting }: { samenvatting: string }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900"
+      >
+        <span className={`transform transition-transform ${open ? 'rotate-90' : ''}`}>
+          &#9654;
+        </span>
+        Regelteksten samenvatting
+      </button>
+      {open && (
+        <p className="mt-2 text-xs text-gray-600 leading-relaxed bg-gray-50 rounded p-2">
+          {samenvatting}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function OntwerpPlannenWarning({ plannen }: { plannen: BestemmingsplanResponse['ontwerp_plannen'] }) {
+  if (plannen.length === 0) return null
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+      <div className="flex items-start gap-2">
+        <span className="text-amber-500 text-sm mt-0.5">&#9888;</span>
+        <div>
+          <h4 className="text-sm font-medium text-amber-800">
+            Ontwerp-bestemmingsplan{plannen.length > 1 ? 'nen' : ''}
+          </h4>
+          <p className="text-xs text-amber-700 mt-0.5">
+            Er {plannen.length === 1 ? 'is' : 'zijn'} {plannen.length} ontwerp-plan
+            {plannen.length > 1 ? 'nen' : ''} voor deze locatie. Dit kan wijzigingen in
+            bouwmogelijkheden betekenen.
+          </p>
+          <ul className="mt-1 space-y-0.5">
+            {plannen.map((p, i) => (
+              <li key={i} className="text-xs text-amber-700">
+                <span className="font-medium">{p.naam || 'Onbekend plan'}</span>
+                {p.datum && <span className="text-amber-600"> ({p.datum})</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// --- Omgeving sub-components ---
+
+function StatistiekenBar({ statistieken_pct }: { statistieken_pct: Record<string, number> }) {
+  const entries = Object.entries(statistieken_pct).filter(([, pct]) => pct > 0)
+  if (entries.length === 0) return null
+
+  return (
+    <div className="space-y-1.5">
+      {entries.map(([cat, pct]) => (
+        <div key={cat} className="flex items-center gap-2">
+          <div
+            className="w-3 h-3 rounded-sm flex-shrink-0"
+            style={{ backgroundColor: CATEGORIE_KLEUREN[cat] || CATEGORIE_KLEUREN.overig }}
+          />
+          <span className="text-xs text-gray-600 w-24 flex-shrink-0">
+            {CATEGORIE_LABELS[cat] || cat}
+          </span>
+          <div className="flex-1 bg-gray-100 rounded-full h-2">
+            <div
+              className="h-2 rounded-full"
+              style={{
+                width: `${Math.min(pct, 100)}%`,
+                backgroundColor: CATEGORIE_KLEUREN[cat] || CATEGORIE_KLEUREN.overig,
+              }}
+            />
+          </div>
+          <span className="text-xs text-gray-500 w-10 text-right">{pct}%</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function BurenBouwinfoSection({ buren }: { buren: BurenBouwinfoItem[] }) {
+  if (buren.length === 0) return null
+
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-gray-700 mb-1.5">Bouwmogelijkheden buren</h4>
+      <div className="space-y-2">
+        {buren.map((b, i) => (
+          <div key={i} className="bg-gray-50 rounded p-2">
+            <span className="text-xs font-medium text-gray-800">{b.bestemming}</span>
+            <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
+              {b.max_bouwhoogte != null && (
+                <span className="text-xs text-gray-500">hoogte: {b.max_bouwhoogte}m</span>
+              )}
+              {b.max_goothoogte != null && (
+                <span className="text-xs text-gray-500">goothoogte: {b.max_goothoogte}m</span>
+              )}
+              {b.max_bebouwingspercentage != null && (
+                <span className="text-xs text-gray-500">bebouwing: {b.max_bebouwingspercentage}%</span>
+              )}
+              {b.max_bouwhoogte == null && b.max_bebouwingspercentage == null && (
+                <span className="text-xs text-gray-400 italic">geen bouwregels gevonden</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function OmgevingSection({
+  lat,
+  lng,
+  onGeoJSONLoaded,
+}: {
+  lat: number
+  lng: number
+  onGeoJSONLoaded?: (data: OmgevingsAnalyseResponse | null) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  const { data: omgeving, isLoading } = useQuery({
+    queryKey: ['omgevingsanalyse', lat, lng],
+    queryFn: () => fetchOmgevingsAnalyse({ lat, lng }),
+    enabled: !!lat && !!lng,
+    staleTime: 30 * 60 * 1000,
+  })
+
+  // Propageer GeoJSON naar parent voor kaartweergave
+  useEffect(() => {
+    if (onGeoJSONLoaded) {
+      onGeoJSONLoaded(omgeving && !omgeving.error ? omgeving : null)
+    }
+  }, [omgeving, onGeoJSONLoaded])
+
+  return (
+    <div className="border-t border-gray-100 pt-3">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 text-sm font-medium text-gray-700 hover:text-gray-900 w-full"
+      >
+        <span className={`transform transition-transform ${open ? 'rotate-90' : ''}`}>
+          &#9654;
+        </span>
+        Omgeving (500m)
+        {isLoading && <span className="text-xs text-gray-400 ml-auto">laden...</span>}
+        {omgeving && !omgeving.error && omgeving.features.length > 0 && (
+          <span className="text-xs text-gray-400 ml-auto">
+            {omgeving.features.length} vlakken
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="mt-3 space-y-3">
+          {isLoading && (
+            <div className="animate-pulse space-y-2">
+              <div className="h-3 bg-gray-200 rounded w-3/4"></div>
+              <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+            </div>
+          )}
+
+          {omgeving && omgeving.error && (
+            <p className="text-xs text-gray-500">{omgeving.error}</p>
+          )}
+
+          {omgeving && !omgeving.error && (
+            <>
+              {/* Statistieken */}
+              {Object.keys(omgeving.statistieken_pct).length > 0 && (
+                <div>
+                  <h4 className="text-sm font-medium text-gray-700 mb-2">Bestemmingen</h4>
+                  <StatistiekenBar statistieken_pct={omgeving.statistieken_pct} />
+                </div>
+              )}
+
+              {/* Ontwerp-plannen in omgeving */}
+              {omgeving.ontwerp_plannen.length > 0 && (
+                <div className="bg-amber-50 border border-amber-200 rounded-lg p-2.5">
+                  <div className="flex items-start gap-1.5">
+                    <span className="text-amber-500 text-xs mt-0.5">&#9888;</span>
+                    <div>
+                      <span className="text-xs font-medium text-amber-800">
+                        {omgeving.ontwerp_plannen.length} ontwerp-plan
+                        {omgeving.ontwerp_plannen.length > 1 ? 'nen' : ''} in de omgeving
+                      </span>
+                      <ul className="mt-0.5 space-y-0.5">
+                        {omgeving.ontwerp_plannen.map((p, i) => (
+                          <li key={i} className="text-xs text-amber-700">
+                            {p.naam || 'Onbekend'}
+                            {p.datum && <span className="text-amber-600"> ({p.datum})</span>}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Buren bouwmogelijkheden */}
+              <BurenBouwinfoSection buren={omgeving.buren_bouwinfo} />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Exports ---
+
+// Re-export kleuren voor BuurtMap
+export { CATEGORIE_KLEUREN }
+
+export default function BestemmingsplanPanel({ lat, lng, onOmgevingGeoJSON }: BestemmingsplanPanelProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['bestemmingsplan', lat, lng],
+    queryFn: () => fetchBestemmingsplan({ lat: lat!, lng: lng! }),
+    enabled: !!lat && !!lng,
+    staleTime: 30 * 60 * 1000,
+  })
+
+  if (!lat || !lng) return null
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">Bestemmingsplan</h3>
+        <div className="animate-pulse space-y-2">
+          <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          <div className="h-4 bg-gray-200 rounded w-2/3"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">Bestemmingsplan</h3>
+        <p className="text-sm text-gray-500">Kon bestemmingsplan niet ophalen.</p>
+      </div>
+    )
+  }
+
+  if (data.error) {
+    return (
+      <div className="bg-white rounded-lg shadow p-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-2">Bestemmingsplan</h3>
+        <p className="text-sm text-gray-500">{data.error}</p>
+        {data.link_plan && (
+          <a
+            href={data.link_plan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-600 hover:underline mt-1 inline-block"
+          >
+            Bekijk op Regels op de Kaart &#8599;
+          </a>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow p-4 space-y-4">
+      {/* Header */}
+      <div>
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">Bestemmingsplan</h3>
+          <BestemmingBadge bestemming={data.bestemming} />
+        </div>
+        <p className="text-sm text-gray-600 mt-0.5">{data.plan_naam}</p>
+        {data.bestemming_specifiek && (
+          <p className="text-xs text-gray-500">{data.bestemming_specifiek}</p>
+        )}
+      </div>
+
+      {/* Uitbreidingsindicator */}
+      {data.uitbreidings_indicator && (
+        <UitbreidingsIndicator
+          indicator={data.uitbreidings_indicator}
+          toelichting={data.uitbreidings_toelichting}
+        />
+      )}
+
+      {/* Bouwregels */}
+      <BouwregelsSection data={data} />
+
+      {/* Functieaanduidingen */}
+      <FunctiesSection items={data.functieaanduidingen} />
+
+      {/* Bouwaanduidingen */}
+      <BouwaanduidingenSection items={data.bouwaanduidingen} />
+
+      {/* Regelteksten */}
+      {data.regels_samenvatting && (
+        <RegelsSection samenvatting={data.regels_samenvatting} />
+      )}
+
+      {/* Ontwerp-plannen waarschuwing */}
+      <OntwerpPlannenWarning plannen={data.ontwerp_plannen} />
+
+      {/* Omgeving sectie */}
+      <OmgevingSection lat={lat} lng={lng} onGeoJSONLoaded={onOmgevingGeoJSON} />
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-2 border-t border-gray-100">
+        <div className="text-xs text-gray-400">
+          {data.plan_type && <span>{data.plan_type}</span>}
+          {data.datum_vaststelling && <span> &middot; {data.datum_vaststelling}</span>}
+        </div>
+        {data.link_plan && (
+          <a
+            href={data.link_plan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-600 hover:underline"
+          >
+            Regels op de Kaart &#8599;
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/BuurtMap.tsx
+++ b/frontend/src/components/BuurtMap.tsx
@@ -4,7 +4,8 @@ import { MapContainer, TileLayer, Marker, Popup, CircleMarker, LayersControl, La
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
-import { fetchBuurtenGeoJSON, fetchWoningenGeoJSON, fetchScholenGeoJSON, fetchPostcode6GeoJSON, formatPrijs } from '../services/api'
+import { fetchBuurtenGeoJSON, fetchWoningenGeoJSON, fetchScholenGeoJSON, fetchPostcode6GeoJSON, formatPrijs, OmgevingsAnalyseResponse } from '../services/api'
+import { CATEGORIE_KLEUREN } from './BestemmingsplanPanel'
 
 // Fix default marker icons for Vite bundler
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -192,12 +193,81 @@ function Postcode6GeoJSONLayer({
   return null
 }
 
+// Imperative bestemmingsvlakken layer
+function BestemmingsvlakkenGeoJSONLayer({
+  data,
+  parentGroup,
+}: {
+  data: GeoJSON.FeatureCollection
+  parentGroup: React.RefObject<L.FeatureGroup | null>
+}) {
+  const layerRef = useRef<L.GeoJSON | null>(null)
+
+  useEffect(() => {
+    const group = parentGroup.current
+    if (!group) return
+
+    if (layerRef.current) {
+      group.removeLayer(layerRef.current)
+      layerRef.current = null
+    }
+
+    if (!data?.features?.length) return
+
+    const layer = L.geoJSON(data, {
+      style: (feature) => {
+        const categorie = feature?.properties?.categorie || 'overig'
+        return {
+          fillColor: CATEGORIE_KLEUREN[categorie] || CATEGORIE_KLEUREN.overig || '#d1d5db',
+          fillOpacity: 0.5,
+          color: '#374151',
+          weight: 1,
+          opacity: 0.6,
+        }
+      },
+      onEachFeature: (feature, featureLayer) => {
+        const props = feature.properties || {}
+        const popup = `<strong>${props.naam || 'Onbekend'}</strong>`
+          + `<br/><em>${props.categorie || ''}</em>`
+          + (props.plan_naam ? `<br/><span style="color:#6b7280;font-size:11px">${props.plan_naam}</span>` : '')
+        featureLayer.bindPopup(popup, { autoPan: false })
+      },
+    })
+
+    group.addLayer(layer)
+    layerRef.current = layer
+
+    return () => {
+      if (layerRef.current && group) {
+        group.removeLayer(layerRef.current)
+      }
+    }
+  }, [data, parentGroup])
+
+  return null
+}
+
+// Component to fly map to a specific center
+function FlyToCenter({ center, zoom }: { center: [number, number]; zoom?: number }) {
+  const map = useMap()
+
+  useEffect(() => {
+    if (center) {
+      map.flyTo(center, zoom || 15, { duration: 1 })
+    }
+  }, [center, zoom, map])
+
+  return null
+}
+
 interface BuurtMapProps {
   gemeente?: string
   minScore?: number
   colorIndicator?: string
   selectedBuurten?: string[]
   onBuurtClick?: (code: string) => void
+  bestemmingsvlakkenGeoJSON?: OmgevingsAnalyseResponse | null
+  bestemmingCenter?: [number, number]
 }
 
 // Color interpolation for dynamic indicator coloring
@@ -233,9 +303,12 @@ export default function BuurtMap({
   colorIndicator = 'score_totaal',
   selectedBuurten = [],
   onBuurtClick,
+  bestemmingsvlakkenGeoJSON,
+  bestemmingCenter,
 }: BuurtMapProps) {
   const buurtGroupRef = useRef<L.FeatureGroup>(null)
   const pc6GroupRef = useRef<L.FeatureGroup>(null)
+  const bestemmingGroupRef = useRef<L.FeatureGroup>(null)
 
   const { data: buurtenGeoJSON, error: geoError } = useQuery({
     queryKey: ['buurten-geojson', gemeente, minScore, colorIndicator],
@@ -321,6 +394,8 @@ export default function BuurtMap({
           maxZoom={19}
         />
 
+        {bestemmingCenter && <FlyToCenter center={bestemmingCenter} zoom={16} />}
+
         <LayersControl position="topright">
           <LayersControl.Overlay name="Buurten" checked>
             <FeatureGroup ref={buurtGroupRef}>
@@ -344,6 +419,17 @@ export default function BuurtMap({
               />
             </FeatureGroup>
           </LayersControl.Overlay>
+
+          {bestemmingsvlakkenGeoJSON && bestemmingsvlakkenGeoJSON.features.length > 0 && (
+            <LayersControl.Overlay name="Bestemmingen" checked>
+              <FeatureGroup ref={bestemmingGroupRef}>
+                <BestemmingsvlakkenGeoJSONLayer
+                  data={bestemmingsvlakkenGeoJSON as unknown as GeoJSON.FeatureCollection}
+                  parentGroup={bestemmingGroupRef}
+                />
+              </FeatureGroup>
+            </LayersControl.Overlay>
+          )}
 
           <LayersControl.Overlay name="Woningen" checked>
             <LayerGroup>{woningMarkers.map((marker, idx) => {

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -11,6 +11,9 @@ import {
   formatM2Prijs,
 } from '../services/api'
 import VoorzieningenPanel from '../components/VoorzieningenPanel'
+import BestemmingsplanPanel from '../components/BestemmingsplanPanel'
+import BuurtMap from '../components/BuurtMap'
+import type { OmgevingsAnalyseResponse } from '../services/api'
 
 function BiedAdviesBadge({ advies }: { advies: string }) {
   const colors: Record<string, string> = {
@@ -656,6 +659,7 @@ export default function WaardebepalingPage() {
   const huisnummerRef = useRef<HTMLInputElement>(null)
 
   const [copied, setCopied] = useState(false)
+  const [omgevingGeoJSON, setOmgevingGeoJSON] = useState<OmgevingsAnalyseResponse | null>(null)
 
   const handleCopy = (waardeMidden: number) => {
     navigator.clipboard.writeText(String(Math.round(waardeMidden)))
@@ -802,10 +806,26 @@ export default function WaardebepalingPage() {
           <div className="lg:col-span-1 space-y-6">
             <WoningGegevensColumn result={result} />
             <VoorzieningenPanel postcode={result.postcode} huisnummer={result.huisnummer} />
+            <BestemmingsplanPanel
+              lat={result.latitude}
+              lng={result.longitude}
+              onOmgevingGeoJSON={setOmgevingGeoJSON}
+            />
           </div>
           <div className="lg:col-span-2">
             <AnalyseColumn result={result} onCopy={handleCopy} copied={copied} />
           </div>
+        </div>
+      )}
+
+      {/* Bestemmingen kaart */}
+      {result && omgevingGeoJSON && omgevingGeoJSON.features.length > 0 && result.latitude && result.longitude && (
+        <div className="mt-6">
+          <h3 className="text-lg font-semibold text-gray-900 mb-2">Bestemmingen omgeving</h3>
+          <BuurtMap
+            bestemmingsvlakkenGeoJSON={omgevingGeoJSON}
+            bestemmingCenter={[result.latitude, result.longitude]}
+          />
         </div>
       )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -196,6 +196,9 @@ export interface EnhancedWaardebepalingResponse {
   monument?: MonumentResponse
   // Funda listing
   funda_listing?: FundaListing
+  // Coordinaten
+  latitude?: number | null
+  longitude?: number | null
   // Data sources
   data_bronnen: string[]
 }
@@ -785,6 +788,110 @@ export async function fetchMarktOverzicht(gemeente?: string) {
   const response = await fetch(`${API_BASE}/markt/overzicht${params}`)
   if (!response.ok) {
     throw new Error('Marktoverzicht ophalen mislukt')
+  }
+  return response.json()
+}
+
+// Bestemmingsplan
+export interface MaatvoeringItem {
+  naam: string
+  waarde: string
+  eenheid?: string | null
+  waarde_type?: string | null
+}
+
+export interface BouwvlakItem {
+  geometrie?: Record<string, unknown> | null
+  maatvoeringen: MaatvoeringItem[]
+}
+
+export interface OntwerpPlanItem {
+  naam: string
+  type: string
+  status: string
+  datum: string
+  id: string
+}
+
+export interface BestemmingsplanResponse {
+  plan_naam: string
+  plan_type: string
+  plan_status: string
+  datum_vaststelling?: string | null
+  bestemming: string
+  bestemming_specifiek?: string | null
+  max_bouwhoogte?: number | null
+  max_goothoogte?: number | null
+  max_bebouwingspercentage?: number | null
+  max_inhoud?: number | null
+  bouwvlak?: BouwvlakItem | null
+  functieaanduidingen: string[]
+  bouwaanduidingen: string[]
+  maatvoeringen: MaatvoeringItem[]
+  regels_samenvatting?: string | null
+  regels_url?: string | null
+  ontwerp_plannen: OntwerpPlanItem[]
+  link_plan: string
+  uitbreidings_indicator?: string | null
+  uitbreidings_toelichting?: string | null
+  error?: string | null
+}
+
+export async function fetchBestemmingsplan(params: {
+  lat: number
+  lng: number
+}): Promise<BestemmingsplanResponse> {
+  const response = await fetch(
+    `${API_BASE}/bestemmingsplan?lat=${params.lat}&lng=${params.lng}`
+  )
+  if (!response.ok) {
+    throw new Error('Bestemmingsplan ophalen mislukt')
+  }
+  return response.json()
+}
+
+// Omgevingsanalyse
+export interface BurenBouwinfoItem {
+  bestemming: string
+  max_bouwhoogte?: number | null
+  max_goothoogte?: number | null
+  max_bebouwingspercentage?: number | null
+}
+
+export interface OmgevingsAnalyseResponse {
+  type: 'FeatureCollection'
+  features: Array<{
+    type: 'Feature'
+    geometry: Record<string, unknown> | null
+    properties: {
+      naam: string
+      categorie: string
+      plan_naam?: string
+    }
+  }>
+  statistieken: Record<string, number>
+  statistieken_pct: Record<string, number>
+  ontwerp_plannen: OntwerpPlanItem[]
+  buren_bouwinfo: BurenBouwinfoItem[]
+  center: [number, number]
+  radius_m: number
+  error?: string | null
+}
+
+export async function fetchOmgevingsAnalyse(params: {
+  lat: number
+  lng: number
+  radius_m?: number
+}): Promise<OmgevingsAnalyseResponse> {
+  const searchParams = new URLSearchParams({
+    lat: String(params.lat),
+    lng: String(params.lng),
+  })
+  if (params.radius_m) searchParams.append('radius_m', String(params.radius_m))
+
+  const response = await fetch(`${API_BASE}/bestemmingsplan/omgeving?${searchParams}`)
+  if (!response.ok) {
+    throw new Error('Omgevingsanalyse ophalen mislukt')
   }
   return response.json()
 }


### PR DESCRIPTION
## Summary

Integreert bestemmingsplannen/omgevingsplannen via de Ruimtelijke Plannen API v4 (DSO). Twee hoofdfeatures:

1. **Bestemmingsplan per woning** — bestemming, bouwregels (bouwhoogte, goothoogte, bebouwingspercentage), functieaanduidingen, bouwaanduidingen, regelteksten, ontwerp-plannen, en een uitbreidingsindicator
2. **Omgevingsanalyse (500m radius)** — alle bestemmingen in de omgeving met GeoJSON kaartweergave, statistieken per categorie, ontwerp-plannen waarschuwing, en bouwmogelijkheden directe buren

### Backend
- `bestemmingsplan_collector.py` — DSO API client met punt- en bbox-queries, categorisatie (13 typen), XHTML regelteksten parsing, 30-dagen cache
- `api/bestemmingsplan.py` — 4 endpoints: `GET /`, `/woning/{id}`, `/omgeving`, `/woning/{id}/omgeving`
- Lat/lng toegevoegd aan `EnhancedWaardebepalingResponse`

### Frontend
- `BestemmingsplanPanel.tsx` — Bouwregels, uitbreidingsindicator, functies, bouwaanduidingen, regels, omgeving-sectie met statistiekenbalk en buren-info
- `BuurtMap.tsx` — Nieuwe "Bestemmingen" layer met categorie-kleuren (geel=wonen, groen=groen, etc.)
- `WaardebepalingPage.tsx` — Integratie van panel + kaart
- `api.ts` — Types en fetch functies

### Vereist
- `DSO_API_KEY` in `.env` (productie-key aanvragen via [omgevingswet.overheid.nl](https://developer.omgevingswet.overheid.nl/formulieren/api-key-aanvragen-0/))

Closes #23

---

## Testplan

Onderstaand testplan doorlopen zodra de DSO productie API-key beschikbaar is.

### Voorbereiding

- [x] DSO productie API-key ontvangen en toegevoegd aan `backend/.env` als `DSO_API_KEY=...`
- [x] Backend gestart: `cd backend && source venv/bin/activate && python run.py`
- [x] Frontend gestart: `cd frontend && npm run dev`

### Test 1: Backend — Bestemmingsplan per locatie (API)

Test via curl met een bekend adres (bijv. centrum Den Haag):

```bash
# Directe locatie-query
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" | python -m json.tool
```

**Verwacht resultaat:**
- [ ] `plan_naam` is gevuld (bijv. "Omgevingsplan Den Haag" of een bestemmingsplan)
- [ ] `plan_type` is gevuld (bijv. "bestemmingsplan" of "omgevingsplan")
- [ ] `bestemming` bevat een naam (bijv. "Wonen", "Gemengd - 1")
- [ ] `maatvoeringen` lijst is niet leeg, bevat items met `naam` en `waarde`
- [ ] `bouwvlak_aanwezig` is `true` of `false` (logisch voor de locatie)
- [ ] `uitbreidings_indicator` is "gunstig", "beperkt", of "ongunstig"
- [ ] Geen `error` veld, of `error: null`

### Test 2: Backend — Bouwregels en details

```bash
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" | python -m json.tool | grep -A2 maatvoeringen
```

**Verwacht resultaat:**
- [ ] Maatvoeringen bevatten herkenbare regels (bouwhoogte, goothoogte, bebouwingspercentage)
- [ ] Waarden zijn numeriek en realistisch (bijv. bouwhoogte 3-30m, niet 0 of 9999)

### Test 3: Backend — Functieaanduidingen en bouwaanduidingen

```bash
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" | python -m json.tool | grep -E "functie|bouwaanduiding"
```

**Verwacht resultaat:**
- [ ] `functieaanduidingen` is een lijst (kan leeg zijn, afhankelijk van locatie)
- [ ] `bouwaanduidingen` is een lijst (kan leeg zijn)
- [ ] Indien gevuld: herkenbare waarden (bijv. "detailhandel", "vrijstaand")

### Test 4: Backend — Ontwerp-plannen

```bash
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" | python -m json.tool | grep -A5 ontwerp
```

**Verwacht resultaat:**
- [ ] `ontwerp_plannen` is een lijst (waarschijnlijk leeg voor de meeste locaties)
- [ ] Indien gevuld: bevat `naam`, `type`, `status`

### Test 5: Backend — Omgevingsanalyse (GeoJSON)

```bash
curl -s "http://localhost:8000/api/bestemmingsplan/omgeving?lat=52.0705&lng=4.3007&radius_m=500" | python -m json.tool | head -50
```

**Verwacht resultaat:**
- [ ] Response is een geldige GeoJSON FeatureCollection (`type: "FeatureCollection"`)
- [ ] `features` lijst bevat meerdere items (minimaal 5-10 in stedelijk gebied)
- [ ] Elk feature heeft `geometry` (Polygon/MultiPolygon) en `properties.categorie`
- [ ] `statistieken` dict is gevuld (bijv. `{"wonen": 15, "groen": 8, ...}`)
- [ ] `statistieken_pct` dict is gevuld met percentages die optellen tot ~100%
- [ ] `center` en `radius_m` komen overeen met de input

### Test 6: Backend — Buren-bouwinfo

```bash
curl -s "http://localhost:8000/api/bestemmingsplan/omgeving?lat=52.0705&lng=4.3007" | python -m json.tool | grep -A10 buren_bouwinfo
```

**Verwacht resultaat:**
- [ ] `buren_bouwinfo` is een lijst (0-3 items)
- [ ] Indien gevuld: bevat `bestemming`, optioneel `max_bouwhoogte`, `max_bebouwingspercentage`

### Test 7: Backend — Caching

```bash
# Eerste call (langzaam, 5-14s door rate limiting)
time curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" > /dev/null

# Tweede call (snel, uit cache)
time curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.0705&lng=4.3007" > /dev/null

# Check cache bestanden
ls -la data/cache/bestemmingsplan/
```

**Verwacht resultaat:**
- [ ] Eerste call: 5-15 seconden
- [ ] Tweede call: < 1 seconde
- [ ] Cache directory bevat JSON bestanden

### Test 8: Backend — Edge cases

```bash
# Locatie zonder bestemmingsplan (midden op zee)
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.5&lng=3.0" | python -m json.tool

# Locatie zonder API key (verwijder DSO_API_KEY tijdelijk)
curl -s "http://localhost:8000/api/bestemmingsplan?lat=52.07&lng=4.30" | python -m json.tool
```

**Verwacht resultaat:**
- [ ] Zee-locatie: response met `error` veld, geen crash
- [ ] Zonder API key: nette foutmelding, geen stack trace

### Test 9: Frontend — WaardebepalingPage integratie

1. Open de frontend in de browser
2. Ga naar de Waardebepaling pagina
3. Voer een geldig adres in (bijv. postcode + huisnummer in Den Haag)
4. Wacht op resultaat

**Verwacht resultaat:**
- [ ] BestemmingsplanPanel verschijnt in de resultaten
- [ ] Toont bestemmingsnaam met gekleurde badge
- [ ] Bouwregels sectie toont maatvoeringen (indien beschikbaar)
- [ ] Uitbreidingsindicator toont gunstig/beperkt/ongunstig met kleur
- [ ] Functieaanduidingen en bouwaanduidingen secties zichtbaar (indien data)
- [ ] Regelteksten sectie (indien beschikbaar van API)

### Test 10: Frontend — Omgeving sectie

1. In het BestemmingsplanPanel, klik op "Omgeving (500m)" om uit te klappen

**Verwacht resultaat:**
- [ ] Statistiekenbalk toont horizontale gekleurde balken per categorie
- [ ] Percentages zijn zichtbaar en tellen op tot ~100%
- [ ] Indien ontwerp-plannen: waarschuwing in oranje/geel
- [ ] Buren-bouwinfo toont compacte lijst van naburige bestemmingen

### Test 11: Frontend — Bestemmingen kaart

1. Scroll naar de kaart "Bestemmingen omgeving" onder de resultaten

**Verwacht resultaat:**
- [ ] Kaart toont gekleurde polygonen voor bestemmingsvlakken
- [ ] Kleuren komen overeen met categorieën (geel=wonen, groen=groen, etc.)
- [ ] Klikken op een vlak toont popup met bestemmingsnaam, categorie, plannaam
- [ ] Layer control bevat "Bestemmingen" als schakelbare overlay
- [ ] Kaart is gecentreerd op de opgezochte locatie

### Test 12: Frontend — Verschillende locaties

Herhaal tests 9-11 met:
- [ ] Een woonwijk (verwacht: veel geel/wonen)
- [ ] Een winkelcentrum/centrum (verwacht: gemengd, detailhandel)
- [ ] Nabij een park (verwacht: groen zichtbaar)
- [ ] Locatie buiten Den Haag (andere gemeente, ander bestemmingsplan)

### Test 13: Frontend — TypeScript compilatie

```bash
cd frontend && npx tsc --noEmit
```

**Verwacht resultaat:**
- [ ] Geen TypeScript fouten

---

## Bekende beperkingen

- **API key vereist**: Zonder `DSO_API_KEY` werkt geen van de bestemmingsplan-features
- **Rate limiting**: Eerste calls duren 5-14s door verplichte vertragingen tussen API-calls
- **Polygon support**: Nog niet bevestigd dat DSO API `_geo.intersects` met Polygon (bbox) accepteert; fallback nodig indien alleen Point wordt ondersteund
- **Data volume**: In dicht bebouwd gebied kunnen veel vlakken terugkomen (max 300, 3 pagina's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)