### PR TITLE
feat: plafondhoogte inschatting via 3DBAG en Funda

### DIFF
--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -22,6 +22,8 @@ from collectors.bag_collector import BagClient
 from collectors.rce_collector import create_rce_collector
 from collectors.pdok_beschermde_gebieden_collector import create_pdok_beschermde_gebieden_collector
 from collectors.funda_collector import create_funda_collector, PropertyListing as FundaPropertyListing
+from collectors.driedbag_collector import create_driedbag_collector
+from services.plafondhoogte import bereken_plafondhoogte, PlafondhoogteResult
 from datetime import datetime, timedelta
 from sqlalchemy import and_
 from utils.address import parse_huisnummer
@@ -137,6 +139,15 @@ class MiljoenhuizenVerkoop(BaseModel):
     woningtype: Optional[str] = None
     geschatte_waarde_laag: Optional[int] = None
     geschatte_waarde_hoog: Optional[int] = None
+
+
+class PlafondhoogteResponse(BaseModel):
+    """Geschatte plafondhoogte indicatie."""
+    geschatte_verdiepingshoogte: Optional[float] = None
+    label: Optional[str] = None
+    methode: Optional[str] = None
+    betrouwbaarheid: Optional[str] = None
+    details: Optional[str] = None
 
 
 class FundaListing(BaseModel):
@@ -282,6 +293,9 @@ class EnhancedWaardebepalingResponse(BaseModel):
 
     # Funda listing
     funda_listing: Optional[FundaListing] = None
+
+    # Plafondhoogte inschatting
+    plafondhoogte: Optional[PlafondhoogteResponse] = None
 
     # Saved woning reference
     woning_id: Optional[int] = None
@@ -1144,6 +1158,44 @@ def bereken_waarde_voor_adres(
     energielabel = energielabel_result.energielabel if energielabel_result else None
     grondoppervlakte = woz_result.oppervlakte if woz_result else None
 
+    # Fetch 3DBAG data and calculate ceiling height estimation
+    driedbag_result = None
+    plafondhoogte_result = None
+    if bag_data and bag_data.get("pand_identificaties"):
+        try:
+            driedbag = create_driedbag_collector()
+            driedbag_result = driedbag.get_building_data(
+                str(bag_data["pand_identificaties"][0])
+            )
+        except Exception:
+            pass
+
+    plafondhoogte_data = bereken_plafondhoogte(
+        h_dak_max=driedbag_result.h_dak_max if driedbag_result else None,
+        h_dak_min=driedbag_result.h_dak_min if driedbag_result else None,
+        h_dak_50p=driedbag_result.h_dak_50p if driedbag_result else None,
+        h_maaiveld=driedbag_result.h_maaiveld if driedbag_result else None,
+        dak_type_3dbag=driedbag_result.dak_type if driedbag_result else None,
+        bouwlagen_3dbag=driedbag_result.bouwlagen if driedbag_result else None,
+        opp_dak_schuin=driedbag_result.opp_dak_schuin if driedbag_result else None,
+        opp_dak_plat=driedbag_result.opp_dak_plat if driedbag_result else None,
+        aantal_bouwlagen=bag_data.get("aantal_bouwlagen") if bag_data else None,
+        inhoud=funda_listing_data.inhoud if funda_listing_data else None,
+        woonoppervlakte=woonoppervlakte,
+        verdiepingen=funda_listing_data.verdiepingen if funda_listing_data else None,
+        dak_type_funda=funda_listing_data.dak_type if funda_listing_data else None,
+    )
+
+    plafondhoogte_response = None
+    if plafondhoogte_data.geschatte_verdiepingshoogte is not None:
+        plafondhoogte_response = PlafondhoogteResponse(
+            geschatte_verdiepingshoogte=plafondhoogte_data.geschatte_verdiepingshoogte,
+            label=plafondhoogte_data.label,
+            methode=plafondhoogte_data.methode,
+            betrouwbaarheid=plafondhoogte_data.betrouwbaarheid,
+            details=plafondhoogte_data.details,
+        )
+
     # Fetch CBS market data for dynamic overbid percentage
     cbs_market_data = None
     market_overbid_pct = None
@@ -1264,6 +1316,8 @@ def bereken_waarde_voor_adres(
         data_bronnen.append("Funda")
     if monument_result and monument_result.heeft_monumentstatus:
         data_bronnen.append("RCE Monumentenregister")
+    if driedbag_result and not driedbag_result.error:
+        data_bronnen.append("3DBAG")
 
     # --- Save/update woning in database ---
     saved_woning_id = None
@@ -1464,5 +1518,6 @@ def bereken_waarde_voor_adres(
         data_bronnen=data_bronnen,
         monument=monument_result,
         funda_listing=funda_listing_data,
+        plafondhoogte=plafondhoogte_response,
         woning_id=saved_woning_id,
     )

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -100,6 +100,11 @@ from collectors.pfas_bodemkaart_collector import (
     BodemkaartResult,
     create_pfas_bodemkaart_collector,
 )
+from collectors.driedbag_collector import (
+    DrieDBagCollector,
+    DrieDBagResult,
+    create_driedbag_collector,
+)
 from collectors.funda_collector import (
     FundaCollector,
     PropertyListing,
@@ -197,6 +202,10 @@ __all__ = [
     "PFASBodemkaartCollector",
     "BodemkaartResult",
     "create_pfas_bodemkaart_collector",
+    # 3DBAG
+    "DrieDBagCollector",
+    "DrieDBagResult",
+    "create_driedbag_collector",
     # Funda
     "FundaCollector",
     "PropertyListing",

--- a/backend/collectors/bag_collector.py
+++ b/backend/collectors/bag_collector.py
@@ -127,6 +127,7 @@ class BagClient:
             "pand_identificaties": None,
             "pand_bouwjaar": None,
             "pand_status": None,
+            "aantal_bouwlagen": None,
         }
 
         bag_info = self.get_nummeraanduiding(postcode, huisnummer, huisletter, toevoeging)
@@ -165,6 +166,7 @@ class BagClient:
                     pand = pand_data.get("pand", {})
                     result["pand_bouwjaar"] = pand.get("oorspronkelijkBouwjaar")
                     result["pand_status"] = pand.get("status")
+                    result["aantal_bouwlagen"] = pand.get("aantalBouwlagen")
             except Exception:
                 pass  # Keep partial results
 

--- a/backend/collectors/driedbag_collector.py
+++ b/backend/collectors/driedbag_collector.py
@@ -1,0 +1,305 @@
+"""
+3DBAG collector for building height and roof data.
+
+Fetches 3D building attributes from api.3dbag.nl, including
+roof height, ground level, roof type, and building volume.
+Used for ceiling height estimation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+]
+
+
+@dataclass
+class DrieDBagResult:
+    """Result from 3DBAG API lookup."""
+
+    pand_identificatie: str
+    h_dak_max: Optional[float] = None
+    h_dak_min: Optional[float] = None
+    h_dak_50p: Optional[float] = None
+    h_dak_70p: Optional[float] = None
+    h_maaiveld: Optional[float] = None
+    dak_type: Optional[str] = None
+    bouwlagen: Optional[int] = None
+    opp_grond: Optional[float] = None
+    opp_dak_plat: Optional[float] = None
+    opp_dak_schuin: Optional[float] = None
+    volume_lod22: Optional[float] = None
+    gebouwhoogte: Optional[float] = None
+    fetch_date: datetime = field(default_factory=datetime.now)
+    source: str = "3dbag.nl"
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pand_identificatie": self.pand_identificatie,
+            "h_dak_max": self.h_dak_max,
+            "h_dak_min": self.h_dak_min,
+            "h_dak_50p": self.h_dak_50p,
+            "h_dak_70p": self.h_dak_70p,
+            "h_maaiveld": self.h_maaiveld,
+            "dak_type": self.dak_type,
+            "bouwlagen": self.bouwlagen,
+            "opp_grond": self.opp_grond,
+            "opp_dak_plat": self.opp_dak_plat,
+            "opp_dak_schuin": self.opp_dak_schuin,
+            "volume_lod22": self.volume_lod22,
+            "gebouwhoogte": self.gebouwhoogte,
+            "fetch_date": self.fetch_date.isoformat(),
+            "source": self.source,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DrieDBagResult":
+        fetch_date = data.get("fetch_date")
+        if isinstance(fetch_date, str):
+            fetch_date = datetime.fromisoformat(fetch_date)
+        elif fetch_date is None:
+            fetch_date = datetime.now()
+
+        return cls(
+            pand_identificatie=data.get("pand_identificatie", ""),
+            h_dak_max=data.get("h_dak_max"),
+            h_dak_min=data.get("h_dak_min"),
+            h_dak_50p=data.get("h_dak_50p"),
+            h_dak_70p=data.get("h_dak_70p"),
+            h_maaiveld=data.get("h_maaiveld"),
+            dak_type=data.get("dak_type"),
+            bouwlagen=data.get("bouwlagen"),
+            opp_grond=data.get("opp_grond"),
+            opp_dak_plat=data.get("opp_dak_plat"),
+            opp_dak_schuin=data.get("opp_dak_schuin"),
+            volume_lod22=data.get("volume_lod22"),
+            gebouwhoogte=data.get("gebouwhoogte"),
+            fetch_date=fetch_date,
+            source=data.get("source", "3dbag.nl"),
+            error=data.get("error"),
+        )
+
+
+@dataclass
+class DrieDBagCollector:
+    """
+    Collector for 3D building data from 3DBAG.
+
+    Fetches building height, roof type, and volume data from the
+    3DBAG API (api.3dbag.nl). Buildings are looked up by BAG
+    pand identificatie.
+
+    Parameters
+    ----------
+    min_delay : float
+        Minimum delay between requests in seconds (default: 1.0)
+    max_delay : float
+        Maximum delay between requests in seconds (default: 2.0)
+    cache_dir : Path, optional
+        Directory for caching results (default: data/cache/3dbag)
+    cache_days : int
+        Number of days to cache results (default: 365)
+    """
+
+    min_delay: float = 1.0
+    max_delay: float = 2.0
+    cache_dir: Optional[Path] = None
+    cache_days: int = 365
+    session: Optional[requests.Session] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    BASE_URL = "https://api.3dbag.nl/collections/pand/items"
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+        if self.cache_dir:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "User-Agent": random.choice(USER_AGENTS),
+            "Accept": "application/city+json",
+        }
+
+    def _rate_limit(self) -> None:
+        now = time.perf_counter()
+        elapsed = now - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.perf_counter()
+
+    def _get_cache_key(self, pand_id: str) -> str:
+        safe_id = pand_id.replace(".", "_")
+        return f"3dbag_{safe_id}"
+
+    def _load_from_cache(self, pand_id: str) -> Optional[DrieDBagResult]:
+        if not self.cache_dir:
+            return None
+
+        cache_path = self.cache_dir / f"{self._get_cache_key(pand_id)}.json"
+        if not cache_path.exists():
+            return None
+
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+
+            result = DrieDBagResult.from_dict(data)
+            cache_age = datetime.now() - result.fetch_date
+            if cache_age > timedelta(days=self.cache_days):
+                return None
+
+            return result
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return None
+
+    def _save_to_cache(self, result: DrieDBagResult) -> None:
+        if not self.cache_dir:
+            return
+
+        cache_path = self.cache_dir / f"{self._get_cache_key(result.pand_identificatie)}.json"
+        try:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(result.to_dict(), f, ensure_ascii=False, indent=2)
+        except IOError:
+            pass
+
+    def _normalize_pand_id(self, pand_identificatie: str) -> str:
+        """Ensure pand ID has the NL.IMBAG.Pand. prefix."""
+        if pand_identificatie.startswith("NL.IMBAG.Pand."):
+            return pand_identificatie
+        return f"NL.IMBAG.Pand.{pand_identificatie}"
+
+    def get_building_data(
+        self,
+        pand_identificatie: str,
+        use_cache: bool = True,
+    ) -> DrieDBagResult:
+        """
+        Fetch 3D building data for a BAG pand.
+
+        Parameters
+        ----------
+        pand_identificatie : str
+            BAG pand identificatie (e.g., "0518100000285158" or
+            "NL.IMBAG.Pand.0518100000285158")
+        use_cache : bool
+            Whether to use cached results (default: True)
+
+        Returns
+        -------
+        DrieDBagResult
+            Building height and roof data
+        """
+        full_id = self._normalize_pand_id(pand_identificatie)
+        raw_id = pand_identificatie.replace("NL.IMBAG.Pand.", "")
+
+        if use_cache:
+            cached = self._load_from_cache(raw_id)
+            if cached:
+                return cached
+
+        result = DrieDBagResult(pand_identificatie=raw_id)
+
+        try:
+            self._rate_limit()
+
+            url = f"{self.BASE_URL}/{full_id}"
+            logger.info(f"Fetching 3DBAG data for {full_id}")
+            response = self.session.get(
+                url,
+                headers=self._get_headers(),
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # CityJSON format: data is nested under feature -> CityObjects
+            feature = data.get("feature", data)
+            city_objects = feature.get("CityObjects", {})
+            if not city_objects:
+                result.error = "Geen gebouwdata gevonden in 3DBAG"
+                if use_cache:
+                    self._save_to_cache(result)
+                return result
+
+            # Get the parent city object (without suffix like -0)
+            # The parent object contains the building-level attributes
+            obj = None
+            for key, val in city_objects.items():
+                if not key.endswith(("-0", "-1", "-2")):
+                    obj = val
+                    break
+            if obj is None:
+                obj = next(iter(city_objects.values()))
+            attrs = obj.get("attributes", {})
+
+            result.h_dak_max = attrs.get("b3_h_dak_max")
+            result.h_dak_min = attrs.get("b3_h_dak_min")
+            result.h_dak_50p = attrs.get("b3_h_dak_50p")
+            result.h_dak_70p = attrs.get("b3_h_dak_70p")
+            result.h_maaiveld = attrs.get("b3_h_maaiveld")
+            result.dak_type = attrs.get("b3_dak_type")
+            result.bouwlagen = attrs.get("b3_bouwlagen")
+            result.opp_grond = attrs.get("b3_opp_grond")
+            result.opp_dak_plat = attrs.get("b3_opp_dak_plat")
+            result.opp_dak_schuin = attrs.get("b3_opp_dak_schuin")
+            result.volume_lod22 = attrs.get("b3_volume_lod22")
+
+            # Compute building height
+            if result.h_dak_max is not None and result.h_maaiveld is not None:
+                result.gebouwhoogte = round(result.h_dak_max - result.h_maaiveld, 2)
+
+            logger.info(
+                f"3DBAG data for {raw_id}: hoogte={result.gebouwhoogte}m, "
+                f"dak={result.dak_type}, bouwlagen={result.bouwlagen}"
+            )
+
+        except requests.RequestException as e:
+            logger.error(f"Error fetching 3DBAG data: {e}")
+            result.error = f"Fout bij ophalen 3DBAG data: {str(e)}"
+
+        if use_cache:
+            self._save_to_cache(result)
+
+        return result
+
+
+def create_driedbag_collector(cache_dir: Optional[Path] = None) -> DrieDBagCollector:
+    """
+    Factory function to create a 3DBAG collector with default cache directory.
+
+    Parameters
+    ----------
+    cache_dir : Path, optional
+        Cache directory. If None, uses data/cache/3dbag.
+
+    Returns
+    -------
+    DrieDBagCollector
+        Configured collector instance
+    """
+    if cache_dir is None:
+        project_root = Path(__file__).parent.parent.parent
+        cache_dir = project_root / "data" / "cache" / "3dbag"
+
+    return DrieDBagCollector(cache_dir=cache_dir)

--- a/backend/services/plafondhoogte.py
+++ b/backend/services/plafondhoogte.py
@@ -1,0 +1,182 @@
+"""
+Plafondhoogte inschatting op basis van 3DBAG en/of Funda data.
+
+Twee methodes:
+- Methode A (3DBAG+BAG): gebouwhoogte / aantal bouwlagen, met dakcorrectie
+- Methode B (Funda): inhoud / woonoppervlakte / verdiepingen
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Dikte vloer/plafondconstructie in meters (gemiddeld)
+CONSTRUCTIE_DIKTE = 0.3
+
+# Correctiefactor voor schuine daken: nokhoogte is hoger dan werkelijke
+# bruikbare hoogte op de bovenste verdieping
+SCHUIN_DAK_CORRECTIE = 0.85
+
+
+@dataclass
+class PlafondhoogteResult:
+    """Resultaat van de plafondhoogte-inschatting."""
+
+    geschatte_verdiepingshoogte: Optional[float] = None
+    label: Optional[str] = None
+    methode: Optional[str] = None
+    betrouwbaarheid: Optional[str] = None
+    details: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "geschatte_verdiepingshoogte": self.geschatte_verdiepingshoogte,
+            "label": self.label,
+            "methode": self.methode,
+            "betrouwbaarheid": self.betrouwbaarheid,
+            "details": self.details,
+        }
+
+
+def _bepaal_label(hoogte: float) -> str:
+    """Bepaal label op basis van geschatte verdiepingshoogte."""
+    if hoogte < 2.6:
+        return "Standaard"
+    elif hoogte < 3.0:
+        return "Ruim"
+    elif hoogte < 3.5:
+        return "Hoog"
+    else:
+        return "Zeer hoog"
+
+
+def _is_schuin_dak(
+    dak_type_3dbag: Optional[str] = None,
+    dak_type_funda: Optional[str] = None,
+    opp_dak_schuin: Optional[float] = None,
+    opp_dak_plat: Optional[float] = None,
+) -> bool:
+    """Bepaal of het gebouw een schuin dak heeft."""
+    if dak_type_3dbag:
+        if "slanted" in dak_type_3dbag.lower():
+            return True
+        if "horizontal" in dak_type_3dbag.lower() or "flat" in dak_type_3dbag.lower():
+            return False
+
+    # Gebruik oppervlakte-verhouding als dak_type niet duidelijk is
+    if opp_dak_schuin is not None and opp_dak_plat is not None:
+        totaal = opp_dak_schuin + opp_dak_plat
+        if totaal > 0 and opp_dak_schuin / totaal > 0.5:
+            return True
+
+    if dak_type_funda:
+        funda_lower = dak_type_funda.lower()
+        if any(w in funda_lower for w in ["schuin", "zadeldak", "mansarde", "puntdak"]):
+            return True
+
+    return False
+
+
+def bereken_plafondhoogte(
+    # 3DBAG data
+    h_dak_max: Optional[float] = None,
+    h_dak_min: Optional[float] = None,
+    h_dak_50p: Optional[float] = None,
+    h_maaiveld: Optional[float] = None,
+    dak_type_3dbag: Optional[str] = None,
+    bouwlagen_3dbag: Optional[int] = None,
+    opp_dak_schuin: Optional[float] = None,
+    opp_dak_plat: Optional[float] = None,
+    # BAG data
+    aantal_bouwlagen: Optional[int] = None,
+    # Funda data
+    inhoud: Optional[int] = None,
+    woonoppervlakte: Optional[int] = None,
+    verdiepingen: Optional[int] = None,
+    dak_type_funda: Optional[str] = None,
+) -> PlafondhoogteResult:
+    """
+    Bereken geschatte plafondhoogte.
+
+    Probeert eerst Methode A (3DBAG + BAG), valt terug op Methode B (Funda).
+
+    Returns
+    -------
+    PlafondhoogteResult
+        Geschatte verdiepingshoogte met label en betrouwbaarheid.
+        Kan lege waarden bevatten als berekening niet mogelijk is.
+    """
+    result = PlafondhoogteResult()
+
+    # Methode A: 3DBAG + BAG
+    bouwlagen = aantal_bouwlagen or bouwlagen_3dbag
+    if h_dak_max is not None and h_maaiveld is not None and bouwlagen and bouwlagen > 0:
+        schuin = _is_schuin_dak(dak_type_3dbag, dak_type_funda, opp_dak_schuin, opp_dak_plat)
+
+        if schuin and h_dak_min is not None:
+            # Bij schuin dak: gebruik mediaan dakhoogte als betere schatting
+            dak_hoogte = h_dak_50p if h_dak_50p is not None else (h_dak_max + h_dak_min) / 2
+        else:
+            dak_hoogte = h_dak_max
+
+        gebouwhoogte = dak_hoogte - h_maaiveld
+        ruwe_hoogte = gebouwhoogte / bouwlagen
+
+        # Trek constructiedikte af
+        geschat = ruwe_hoogte - CONSTRUCTIE_DIKTE
+
+        # Sanity check
+        if 2.0 <= geschat <= 6.0:
+            result.geschatte_verdiepingshoogte = round(geschat, 1)
+            result.label = _bepaal_label(result.geschatte_verdiepingshoogte)
+            result.methode = "3DBAG+BAG"
+            result.betrouwbaarheid = "hoog"
+
+            details_parts = [
+                f"Gebouwhoogte {gebouwhoogte:.1f}m",
+                f"{bouwlagen} bouwlagen",
+            ]
+            if schuin:
+                details_parts.append("correctie schuin dak")
+            result.details = ", ".join(details_parts)
+
+            logger.info(
+                f"Plafondhoogte (3DBAG): {result.geschatte_verdiepingshoogte}m "
+                f"({result.label})"
+            )
+            return result
+        else:
+            logger.warning(
+                f"Plafondhoogte sanity check mislukt: {geschat:.1f}m "
+                f"(gebouwhoogte={gebouwhoogte:.1f}m, bouwlagen={bouwlagen})"
+            )
+
+    # Methode B: Funda (inhoud / oppervlakte / verdiepingen)
+    if inhoud and woonoppervlakte and woonoppervlakte > 0:
+        etages = verdiepingen if verdiepingen and verdiepingen > 0 else 1
+        geschat = inhoud / woonoppervlakte / etages
+
+        # Sanity check
+        if 2.0 <= geschat <= 6.0:
+            result.geschatte_verdiepingshoogte = round(geschat, 1)
+            result.label = _bepaal_label(result.geschatte_verdiepingshoogte)
+            result.methode = "Funda"
+            result.betrouwbaarheid = "gemiddeld" if verdiepingen else "laag"
+            result.details = f"Inhoud {inhoud}m³ / {woonoppervlakte}m² / {etages} woonlagen"
+
+            logger.info(
+                f"Plafondhoogte (Funda): {result.geschatte_verdiepingshoogte}m "
+                f"({result.label})"
+            )
+            return result
+        else:
+            logger.warning(
+                f"Plafondhoogte Funda sanity check mislukt: {geschat:.1f}m "
+                f"(inhoud={inhoud}, opp={woonoppervlakte}, etages={etages})"
+            )
+
+    return result

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -423,16 +423,9 @@ function FundaListingPanel({ listing, bagWoonoppervlakte, plafondhoogte }: { lis
           {detailRow('Isolatie', listing.isolatie)}
           {detailRow('Verwarming', listing.verwarming)}
           {detailRow('Dak', listing.dak_type)}
-          {plafondhoogte?.geschatte_verdiepingshoogte && (
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-500">Geschatte plafondhoogte</span>
-              <span className="text-gray-900 font-medium">
-                ~{plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m
-                <span className="ml-1 text-xs text-gray-400">
-                  ({plafondhoogte.label}{plafondhoogte.betrouwbaarheid ? `, ${plafondhoogte.betrouwbaarheid}` : ''})
-                </span>
-              </span>
-            </div>
+          {plafondhoogte?.geschatte_verdiepingshoogte && detailRow(
+            'Geschatte plafondhoogte',
+            `~${plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m (${plafondhoogte.label}${plafondhoogte.betrouwbaarheid ? `, ${plafondhoogte.betrouwbaarheid}` : ''})`
           )}
         </div>
       )}
@@ -564,16 +557,13 @@ function AnalyseColumn({ result, onCopy, copied }: {
         <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
           <h3 className="text-sm font-semibold text-orange-800 mb-2">Geschatte plafondhoogte</h3>
           <div className="flex justify-between text-sm">
-            <span className="text-gray-600">Verdiepingshoogte</span>
-            <span className="text-gray-900 font-medium">
-              ~{result.plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m
-              <span className="ml-1 text-xs text-gray-400">
-                ({result.plafondhoogte.label}{result.plafondhoogte.betrouwbaarheid ? `, ${result.plafondhoogte.betrouwbaarheid}` : ''})
-              </span>
+            <span className="text-orange-600">Verdiepingshoogte</span>
+            <span className="text-orange-800 font-medium text-right max-w-[60%]">
+              ~{result.plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m ({result.plafondhoogte.label}{result.plafondhoogte.betrouwbaarheid ? `, ${result.plafondhoogte.betrouwbaarheid}` : ''})
             </span>
           </div>
           {result.plafondhoogte.details && (
-            <div className="text-xs text-gray-400 mt-1">{result.plafondhoogte.details}</div>
+            <div className="text-xs text-orange-400 mt-1">{result.plafondhoogte.details}</div>
           )}
         </div>
       )}

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -7,6 +7,7 @@ import {
   EnhancedWaardebepalingResponse,
   MonumentResponse,
   FundaListing,
+  PlafondhoogteResponse,
   formatPrijs,
   formatM2Prijs,
 } from '../services/api'
@@ -308,7 +309,7 @@ function WoningGegevensColumn({ result }: { result: EnhancedWaardebepalingRespon
   )
 }
 
-function FundaListingPanel({ listing, bagWoonoppervlakte }: { listing: FundaListing, bagWoonoppervlakte?: number }) {
+function FundaListingPanel({ listing, bagWoonoppervlakte, plafondhoogte }: { listing: FundaListing, bagWoonoppervlakte?: number, plafondhoogte?: PlafondhoogteResponse }) {
   const detailRow = (label: string, value: string | number | boolean | undefined | null) => {
     if (value === undefined || value === null) return null
     const display = typeof value === 'boolean' ? (value ? 'Ja' : 'Nee') : String(value)
@@ -416,12 +417,23 @@ function FundaListingPanel({ listing, bagWoonoppervlakte }: { listing: FundaList
       )}
 
       {/* Extra */}
-      {(listing.isolatie || listing.verwarming || listing.dak_type) && (
+      {(listing.isolatie || listing.verwarming || listing.dak_type || plafondhoogte?.geschatte_verdiepingshoogte) && (
         <div className="border-t border-orange-200 pt-2 mt-2 space-y-1">
           <div className="text-xs text-orange-500 font-medium uppercase tracking-wide">Technisch</div>
           {detailRow('Isolatie', listing.isolatie)}
           {detailRow('Verwarming', listing.verwarming)}
           {detailRow('Dak', listing.dak_type)}
+          {plafondhoogte?.geschatte_verdiepingshoogte && (
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Geschatte plafondhoogte</span>
+              <span className="text-gray-900 font-medium">
+                ~{plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m
+                <span className="ml-1 text-xs text-gray-400">
+                  ({plafondhoogte.label}{plafondhoogte.betrouwbaarheid ? `, ${plafondhoogte.betrouwbaarheid}` : ''})
+                </span>
+              </span>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -544,7 +556,26 @@ function AnalyseColumn({ result, onCopy, copied }: {
 
       {/* Funda listing */}
       {result.funda_listing && (
-        <FundaListingPanel listing={result.funda_listing} bagWoonoppervlakte={result.woonoppervlakte} />
+        <FundaListingPanel listing={result.funda_listing} bagWoonoppervlakte={result.woonoppervlakte} plafondhoogte={result.plafondhoogte} />
+      )}
+
+      {/* Plafondhoogte (standalone als geen Funda listing) */}
+      {!result.funda_listing && result.plafondhoogte?.geschatte_verdiepingshoogte && (
+        <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+          <h3 className="text-sm font-semibold text-orange-800 mb-2">Geschatte plafondhoogte</h3>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Verdiepingshoogte</span>
+            <span className="text-gray-900 font-medium">
+              ~{result.plafondhoogte.geschatte_verdiepingshoogte.toFixed(1)}m
+              <span className="ml-1 text-xs text-gray-400">
+                ({result.plafondhoogte.label}{result.plafondhoogte.betrouwbaarheid ? `, ${result.plafondhoogte.betrouwbaarheid}` : ''})
+              </span>
+            </span>
+          </div>
+          {result.plafondhoogte.details && (
+            <div className="text-xs text-gray-400 mt-1">{result.plafondhoogte.details}</div>
+          )}
+        </div>
       )}
 
       {/* Marktindicatoren */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -196,6 +196,8 @@ export interface EnhancedWaardebepalingResponse {
   monument?: MonumentResponse
   // Funda listing
   funda_listing?: FundaListing
+  // Plafondhoogte inschatting
+  plafondhoogte?: PlafondhoogteResponse
   // Data sources
   data_bronnen: string[]
 }
@@ -233,6 +235,15 @@ export interface MonumentResponse {
   beschermd_gezicht?: BeschermdGezichtInfo
   unesco?: UnescoInfo
   heeft_monumentstatus: boolean
+}
+
+// Plafondhoogte inschatting
+export interface PlafondhoogteResponse {
+  geschatte_verdiepingshoogte?: number
+  label?: string
+  methode?: string
+  betrouwbaarheid?: string
+  details?: string
 }
 
 // GeoJSON types


### PR DESCRIPTION
## Summary

- **Nieuwe 3DBAG collector** voor gebouwhoogte, daktype en bouwlagen via `api.3dbag.nl`
- **Berekeningsmodule** met twee methodes en automatische fallback:
  - **Methode A (3DBAG+BAG):** `(dakhoogte - maaiveld) / bouwlagen - 0.3m` met correctie voor schuin dak
  - **Methode B (Funda):** `inhoud / woonoppervlakte / verdiepingen` als fallback
- **BAG collector** uitgebreid met `aantal_bouwlagen` extractie
- **Labels:** Standaard (<2.6m), Ruim (2.6-3.0m), Hoog (3.0-3.5m), Zeer hoog (≥3.5m)
- **Frontend:** weergave in Technisch-sectie met betrouwbaarheidsindicatie

## Test plan

- [x] Waardebepaling uitvoeren voor een adres met BAG API key → controleer dat `plafondhoogte` in response zit
- [x] Controleer dat 3DBAG data correct wordt opgehaald (gebouwhoogte, daktype)
- [x] Test fallback naar Funda-methode als 3DBAG niet beschikbaar is
- [x] Test met schuin dak vs plat dak (correctiefactor)
- [x] Verifieer sanity checks: resultaat <2.0m of >6.0m geeft `null`
- [x] Frontend: plafondhoogte zichtbaar in Technisch-sectie bij woningdetails
- [x] Frontend: standalone weergave als er geen Funda listing is

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)