### PR TITLE
feat: zon & oriëntatie analyse met BGT tuindetectie

### DIFF
--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -772,6 +772,54 @@ WKPB_WFS_URL = "https://service.pdok.nl/kadaster/wkpb/wfs/v1_0"
 PDOK_LOCATIE_URL = "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free"
 
 
+def _lookup_pand_id_pdok(postcode: str, huisnummer: int) -> Optional[str]:
+    """Lookup pand identificatie via free PDOK BAG WFS (no API key needed)."""
+    try:
+        # Step 1: Get adresseerbaarobject_id from PDOK Locatieserver
+        resp = requests.get(
+            "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free",
+            params={
+                "q": f"{postcode} {huisnummer}",
+                "fq": "type:adres",
+                "fl": "adresseerbaarobject_id",
+                "rows": 1,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        docs = resp.json().get("response", {}).get("docs", [])
+        if not docs:
+            return None
+
+        vbo_id = docs[0].get("adresseerbaarobject_id")
+        if not vbo_id:
+            return None
+
+        # Step 2: Get pandidentificatie from PDOK BAG WFS
+        resp2 = requests.get(
+            "https://service.pdok.nl/lv/bag/wfs/v2_0",
+            params={
+                "service": "WFS",
+                "version": "2.0.0",
+                "request": "GetFeature",
+                "typeName": "bag:verblijfsobject",
+                "outputFormat": "application/json",
+                "CQL_FILTER": f"identificatie='{vbo_id}'",
+                "count": 1,
+            },
+            timeout=10,
+        )
+        resp2.raise_for_status()
+        features = resp2.json().get("features", [])
+        if features:
+            pand_id = features[0].get("properties", {}).get("pandidentificatie")
+            if pand_id:
+                return str(pand_id)
+    except Exception:
+        pass
+    return None
+
+
 def _lookup_wkpb(postcode: str, huisnummer: int) -> Dict[str, Any]:
     """
     Query Kadaster WKPB (publiekrechtelijke beperkingen) for monument status.
@@ -1203,13 +1251,21 @@ def bereken_waarde_voor_adres(
 
     # Fetch 3DBAG data and calculate ceiling height estimation
     driedbag_result = None
+    driedbag = create_driedbag_collector()
     plafondhoogte_result = None
+    pand_identificatie = None
+
     if bag_data and bag_data.get("pand_identificaties"):
+        pand_identificatie = str(bag_data["pand_identificaties"][0])
+    else:
+        # Fallback: lookup pand ID via free PDOK BAG WFS
+        pand_identificatie = _lookup_pand_id_pdok(
+            request.postcode, request.huisnummer
+        )
+
+    if pand_identificatie:
         try:
-            driedbag = create_driedbag_collector()
-            driedbag_result = driedbag.get_building_data(
-                str(bag_data["pand_identificaties"][0])
-            )
+            driedbag_result = driedbag.get_building_data(pand_identificatie)
         except Exception:
             pass
 

--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -164,6 +164,29 @@ class GlasvezelResponse(BaseModel):
     adres_gevonden: bool = False
 
 
+class OrientatieResponse(BaseModel):
+    """Zon en oriëntatie analyse."""
+    tuin_orientatie: Optional[str] = None
+    tuin_azimut: Optional[float] = None
+    tuin_oppervlakte_berekend: Optional[float] = None
+    zon_uren_zomer: Optional[float] = None
+    zon_uren_lente: Optional[float] = None
+    zon_uren_winter: Optional[float] = None
+    zon_label: Optional[str] = None
+    schaduw_eigen_gebouw: Optional[str] = None
+    schaduw_buren: Optional[str] = None
+    schaduw_bomen: Optional[str] = None
+    effectieve_tuin_diepte: Optional[float] = None
+    zonnepanelen_score: Optional[int] = None
+    zonnepanelen_label: Optional[str] = None
+    dak_orientatie: Optional[str] = None
+    dak_hellingshoek: Optional[float] = None
+    geschikt_dakoppervlak: Optional[float] = None
+    methode: Optional[str] = None
+    betrouwbaarheid: Optional[str] = None
+    details: Optional[str] = None
+
+
 class FundaListing(BaseModel):
     """Funda listing data for a property."""
     url: str
@@ -313,6 +336,9 @@ class EnhancedWaardebepalingResponse(BaseModel):
 
     # Glasvezel beschikbaarheid
     glasvezel: Optional[GlasvezelResponse] = None
+
+    # Zon en oriëntatie
+    orientatie: Optional[OrientatieResponse] = None
 
     # Saved woning reference
     woning_id: Optional[int] = None
@@ -1213,6 +1239,78 @@ def bereken_waarde_voor_adres(
             details=plafondhoogte_data.details,
         )
 
+    # Zon en oriëntatie analyse
+    orientatie_response = None
+    try:
+        from services.orientatie import bereken_orientatie
+        from collectors.perceelgrens_collector import create_perceelgrens_collector
+        from collectors.bgt_boom_collector import create_bgt_boom_collector
+
+        footprint_rd = driedbag_result.footprint_rd if driedbag_result else None
+
+        # Bereken centroid voor spatial queries
+        orientatie_rd_x, orientatie_rd_y = None, None
+        if footprint_rd:
+            orientatie_rd_x = sum(p[0] for p in footprint_rd) / len(footprint_rd)
+            orientatie_rd_y = sum(p[1] for p in footprint_rd) / len(footprint_rd)
+
+        perceel_polygon = None
+        buurtgebouwen = []
+        bomen = []
+
+        if orientatie_rd_x and orientatie_rd_y:
+            # Perceelgrenzen ophalen
+            try:
+                perceel_collector = create_perceelgrens_collector()
+                perceel_result = perceel_collector.get_perceel(
+                    orientatie_rd_x, orientatie_rd_y,
+                    building_footprint_rd=footprint_rd,
+                )
+                perceel_polygon = perceel_result.perceel_polygon_rd
+            except Exception:
+                pass
+
+            # Buurtgebouwen ophalen
+            try:
+                pand_id = driedbag_result.pand_identificatie if driedbag_result else None
+                buurtgebouwen = driedbag.get_surrounding_buildings(
+                    orientatie_rd_x, orientatie_rd_y,
+                    radius=75,
+                    exclude_pand_id=pand_id,
+                )
+            except Exception:
+                pass
+
+            # BGT bomen met AHN hoogtes
+            try:
+                boom_collector = create_bgt_boom_collector()
+                bomen = boom_collector.get_trees(
+                    orientatie_rd_x, orientatie_rd_y, radius=75
+                )
+            except Exception:
+                pass
+
+        orientatie_data = bereken_orientatie(
+            building_footprint_rd=footprint_rd,
+            perceel_polygon_rd=perceel_polygon,
+            gebouwhoogte=driedbag_result.gebouwhoogte if driedbag_result else None,
+            dak_azimut=driedbag_result.dak_azimut if driedbag_result else None,
+            dak_hellingshoek=driedbag_result.dak_hellingshoek if driedbag_result else None,
+            opp_dak_schuin=driedbag_result.opp_dak_schuin if driedbag_result else None,
+            opp_dak_plat=driedbag_result.opp_dak_plat if driedbag_result else None,
+            dak_type=driedbag_result.dak_type if driedbag_result else None,
+            buurtgebouwen=buurtgebouwen,
+            bomen=bomen,
+            funda_tuin_orientatie=funda_listing_data.tuin_orientatie if funda_listing_data else None,
+        )
+
+        if orientatie_data.tuin_orientatie or orientatie_data.zonnepanelen_score:
+            orientatie_response = OrientatieResponse(
+                **orientatie_data.to_dict()
+            )
+    except Exception:
+        pass
+
     # Fetch CBS market data for dynamic overbid percentage
     cbs_market_data = None
     market_overbid_pct = None
@@ -1561,5 +1659,6 @@ def bereken_waarde_voor_adres(
         funda_listing=funda_listing_data,
         plafondhoogte=plafondhoogte_response,
         glasvezel=glasvezel_response,
+        orientatie=orientatie_response,
         woning_id=saved_woning_id,
     )

--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -184,6 +184,7 @@ class OrientatieResponse(BaseModel):
     geschikt_dakoppervlak: Optional[float] = None
     funda_tuin_orientatie: Optional[str] = None
     funda_tuin_oppervlakte: Optional[int] = None
+    tuin_oppervlakte_bron: Optional[str] = None
     methode: Optional[str] = None
     betrouwbaarheid: Optional[str] = None
     details: Optional[str] = None

--- a/backend/api/waardebepaling.py
+++ b/backend/api/waardebepaling.py
@@ -182,6 +182,8 @@ class OrientatieResponse(BaseModel):
     dak_orientatie: Optional[str] = None
     dak_hellingshoek: Optional[float] = None
     geschikt_dakoppervlak: Optional[float] = None
+    funda_tuin_orientatie: Optional[str] = None
+    funda_tuin_oppervlakte: Optional[int] = None
     methode: Optional[str] = None
     betrouwbaarheid: Optional[str] = None
     details: Optional[str] = None
@@ -772,16 +774,23 @@ WKPB_WFS_URL = "https://service.pdok.nl/kadaster/wkpb/wfs/v1_0"
 PDOK_LOCATIE_URL = "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free"
 
 
-def _lookup_pand_id_pdok(postcode: str, huisnummer: int) -> Optional[str]:
-    """Lookup pand identificatie via free PDOK BAG WFS (no API key needed)."""
+def _lookup_pand_id_pdok(
+    postcode: str, huisnummer: int
+) -> tuple[Optional[str], Optional[float], Optional[float]]:
+    """Lookup pand identificatie and RD coordinates via free PDOK.
+
+    Returns (pand_id, rd_x, rd_y) where rd_x/rd_y are the address
+    coordinates from the PDOK locatieserver.
+    """
+    rd_x, rd_y = None, None
     try:
-        # Step 1: Get adresseerbaarobject_id from PDOK Locatieserver
+        # Step 1: Get adresseerbaarobject_id + centroid from PDOK Locatieserver
         resp = requests.get(
             "https://api.pdok.nl/bzk/locatieserver/search/v3_1/free",
             params={
                 "q": f"{postcode} {huisnummer}",
                 "fq": "type:adres",
-                "fl": "adresseerbaarobject_id",
+                "fl": "adresseerbaarobject_id,centroide_rd",
                 "rows": 1,
             },
             timeout=10,
@@ -789,11 +798,20 @@ def _lookup_pand_id_pdok(postcode: str, huisnummer: int) -> Optional[str]:
         resp.raise_for_status()
         docs = resp.json().get("response", {}).get("docs", [])
         if not docs:
-            return None
+            return None, None, None
+
+        # Parse RD coordinates from "POINT(x y)" format
+        centroid_str = docs[0].get("centroide_rd", "")
+        if centroid_str:
+            import re as _re
+            m = _re.match(r"POINT\(([\d.]+)\s+([\d.]+)\)", centroid_str)
+            if m:
+                rd_x = float(m.group(1))
+                rd_y = float(m.group(2))
 
         vbo_id = docs[0].get("adresseerbaarobject_id")
         if not vbo_id:
-            return None
+            return None, rd_x, rd_y
 
         # Step 2: Get pandidentificatie from PDOK BAG WFS
         resp2 = requests.get(
@@ -814,10 +832,10 @@ def _lookup_pand_id_pdok(postcode: str, huisnummer: int) -> Optional[str]:
         if features:
             pand_id = features[0].get("properties", {}).get("pandidentificatie")
             if pand_id:
-                return str(pand_id)
+                return str(pand_id), rd_x, rd_y
     except Exception:
         pass
-    return None
+    return None, rd_x, rd_y
 
 
 def _lookup_wkpb(postcode: str, huisnummer: int) -> Dict[str, Any]:
@@ -1254,18 +1272,40 @@ def bereken_waarde_voor_adres(
     driedbag = create_driedbag_collector()
     plafondhoogte_result = None
     pand_identificatie = None
+    adres_rd_x, adres_rd_y = None, None  # True address coordinates from PDOK
+
+    # Always get PDOK coordinates (authoritative location)
+    pdok_pand_id, adres_rd_x, adres_rd_y = _lookup_pand_id_pdok(
+        request.postcode, request.huisnummer
+    )
 
     if bag_data and bag_data.get("pand_identificaties"):
         pand_identificatie = str(bag_data["pand_identificaties"][0])
-    else:
-        # Fallback: lookup pand ID via free PDOK BAG WFS
-        pand_identificatie = _lookup_pand_id_pdok(
-            request.postcode, request.huisnummer
-        )
+    elif pdok_pand_id:
+        pand_identificatie = pdok_pand_id
 
     if pand_identificatie:
         try:
             driedbag_result = driedbag.get_building_data(pand_identificatie)
+        except Exception:
+            pass
+
+    # Validate: if 3DBAG footprint is far from PDOK address, use spatial lookup
+    if driedbag_result and driedbag_result.footprint_rd and adres_rd_x and adres_rd_y:
+        fp = driedbag_result.footprint_rd
+        fp_cx = sum(p[0] for p in fp) / len(fp)
+        fp_cy = sum(p[1] for p in fp) / len(fp)
+        dist = ((fp_cx - adres_rd_x) ** 2 + (fp_cy - adres_rd_y) ** 2) ** 0.5
+        if dist > 100:  # footprint > 100m from address = wrong building
+            driedbag_result = None
+
+    # Fallback: spatial lookup by RD coordinates
+    if (not driedbag_result or not driedbag_result.footprint_rd) and adres_rd_x and adres_rd_y:
+        try:
+            loc_result = driedbag.get_building_by_location(adres_rd_x, adres_rd_y)
+            if loc_result and loc_result.footprint_rd:
+                driedbag_result = loc_result
+                pand_identificatie = loc_result.pand_identificatie
         except Exception:
             pass
 
@@ -1301,20 +1341,32 @@ def bereken_waarde_voor_adres(
         from services.orientatie import bereken_orientatie
         from collectors.perceelgrens_collector import create_perceelgrens_collector
         from collectors.bgt_boom_collector import create_bgt_boom_collector
+        from collectors.bgt_wegdeel_collector import create_bgt_wegdeel_collector
 
         footprint_rd = driedbag_result.footprint_rd if driedbag_result else None
 
-        # Bereken centroid voor spatial queries
-        orientatie_rd_x, orientatie_rd_y = None, None
-        if footprint_rd:
+        # Gebruik PDOK adrescoördinaten als primaire locatie (altijd betrouwbaar),
+        # footprint centroid als fallback
+        orientatie_rd_x, orientatie_rd_y = adres_rd_x, adres_rd_y
+        if not orientatie_rd_x and footprint_rd:
             orientatie_rd_x = sum(p[0] for p in footprint_rd) / len(footprint_rd)
             orientatie_rd_y = sum(p[1] for p in footprint_rd) / len(footprint_rd)
 
         perceel_polygon = None
         buurtgebouwen = []
         bomen = []
+        road_polygons = []
 
         if orientatie_rd_x and orientatie_rd_y:
+            # BGT wegdelen ophalen (voorkant-detectie)
+            try:
+                weg_collector = create_bgt_wegdeel_collector()
+                road_polygons = weg_collector.get_roads(
+                    orientatie_rd_x, orientatie_rd_y, radius=50
+                )
+            except Exception:
+                pass
+
             # Perceelgrenzen ophalen
             try:
                 perceel_collector = create_perceelgrens_collector()
@@ -1346,7 +1398,16 @@ def bereken_waarde_voor_adres(
             except Exception:
                 pass
 
+        # Funda tuin-data voor vergelijking
+        funda_tuin_orientatie = None
+        funda_tuin_oppervlakte = None
+        if funda_listing_data:
+            funda_tuin_orientatie = funda_listing_data.tuin_orientatie
+            funda_tuin_oppervlakte = funda_listing_data.tuin_oppervlakte
+
         orientatie_data = bereken_orientatie(
+            rd_x=orientatie_rd_x or 0.0,
+            rd_y=orientatie_rd_y or 0.0,
             building_footprint_rd=footprint_rd,
             perceel_polygon_rd=perceel_polygon,
             gebouwhoogte=driedbag_result.gebouwhoogte if driedbag_result else None,
@@ -1355,9 +1416,12 @@ def bereken_waarde_voor_adres(
             opp_dak_schuin=driedbag_result.opp_dak_schuin if driedbag_result else None,
             opp_dak_plat=driedbag_result.opp_dak_plat if driedbag_result else None,
             dak_type=driedbag_result.dak_type if driedbag_result else None,
+            dak_delen=driedbag_result.dak_delen if driedbag_result else None,
             buurtgebouwen=buurtgebouwen,
             bomen=bomen,
-            funda_tuin_orientatie=funda_listing_data.tuin_orientatie if funda_listing_data else None,
+            road_polygons=road_polygons,
+            funda_tuin_orientatie=funda_tuin_orientatie,
+            funda_tuin_oppervlakte=funda_tuin_oppervlakte,
         )
 
         if orientatie_data.tuin_orientatie or orientatie_data.zonnepanelen_score:

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -119,6 +119,10 @@ from collectors.bgt_boom_collector import (
     BgtBoomCollector,
     create_bgt_boom_collector,
 )
+from collectors.bgt_wegdeel_collector import (
+    BgtWegdeelCollector,
+    create_bgt_wegdeel_collector,
+)
 from collectors.funda_collector import (
     FundaCollector,
     PropertyListing,
@@ -231,6 +235,9 @@ __all__ = [
     # BGT Bomen + AHN
     "BgtBoomCollector",
     "create_bgt_boom_collector",
+    # BGT Wegdelen (voorkant-detectie)
+    "BgtWegdeelCollector",
+    "create_bgt_wegdeel_collector",
     # Funda
     "FundaCollector",
     "PropertyListing",

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -110,6 +110,15 @@ from collectors.glasvezel_collector import (
     GlasvezelResult,
     create_glasvezel_collector,
 )
+from collectors.perceelgrens_collector import (
+    PerceelgrensCollector,
+    PerceelgrensResult,
+    create_perceelgrens_collector,
+)
+from collectors.bgt_boom_collector import (
+    BgtBoomCollector,
+    create_bgt_boom_collector,
+)
 from collectors.funda_collector import (
     FundaCollector,
     PropertyListing,
@@ -215,6 +224,13 @@ __all__ = [
     "GlasvezelCollector",
     "GlasvezelResult",
     "create_glasvezel_collector",
+    # Perceelgrenzen (Kadaster)
+    "PerceelgrensCollector",
+    "PerceelgrensResult",
+    "create_perceelgrens_collector",
+    # BGT Bomen + AHN
+    "BgtBoomCollector",
+    "create_bgt_boom_collector",
     # Funda
     "FundaCollector",
     "PropertyListing",

--- a/backend/collectors/bgt_boom_collector.py
+++ b/backend/collectors/bgt_boom_collector.py
@@ -1,0 +1,327 @@
+"""
+BGT boom collector with AHN height data.
+
+Fetches tree positions from the BGT (Basisregistratie Grootschalige
+Topografie) and determines tree heights using the AHN (Actueel
+Hoogtebestand Nederland) DSM/DTM difference.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+]
+
+BGT_URL = "https://api.pdok.nl/lv/bgt/ogc/v1/collections/vegetatieobject_punt/items"
+AHN_WCS_URL = "https://service.pdok.nl/rws/ahn/wcs/v1_0"
+
+
+@dataclass
+class BgtBoomCollector:
+    """Collector for tree positions (BGT) and heights (AHN).
+
+    Parameters
+    ----------
+    min_delay : float
+        Minimum delay between requests in seconds
+    max_delay : float
+        Maximum delay between requests in seconds
+    cache_dir : Path, optional
+        Directory for caching results
+    cache_days : int
+        Number of days to cache results (default: 365)
+    """
+
+    min_delay: float = 1.0
+    max_delay: float = 2.0
+    cache_dir: Optional[Path] = None
+    cache_days: int = 365
+    session: Optional[requests.Session] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+        if self.cache_dir:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _rate_limit(self) -> None:
+        now = time.perf_counter()
+        elapsed = now - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.perf_counter()
+
+    def get_trees(
+        self,
+        rd_x: float,
+        rd_y: float,
+        radius: float = 75.0,
+        use_cache: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Fetch trees near a location with heights.
+
+        Parameters
+        ----------
+        rd_x, rd_y : float
+            Center point in RD coordinates (EPSG:28992)
+        radius : float
+            Search radius in meters (default: 75m)
+        use_cache : bool
+            Whether to use cached results
+
+        Returns
+        -------
+        list of dict
+            Each dict has: rd_x, rd_y, hoogte (meters above ground)
+        """
+        cache_key = f"bomen_{int(rd_x)}_{int(rd_y)}_{int(radius)}"
+
+        if use_cache and self.cache_dir:
+            cache_path = self.cache_dir / f"{cache_key}.json"
+            if cache_path.exists():
+                try:
+                    with open(cache_path, "r", encoding="utf-8") as f:
+                        cached = json.load(f)
+                    cache_date = datetime.fromisoformat(cached.get("fetch_date", ""))
+                    if datetime.now() - cache_date < timedelta(days=self.cache_days):
+                        return cached.get("trees", [])
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+        # Convert RD to WGS84 for BGT OGC API bbox
+        tree_positions = self._fetch_tree_positions(rd_x, rd_y, radius)
+
+        if not tree_positions:
+            self._save_cache(cache_key, [])
+            return []
+
+        # Get heights from AHN for all tree positions
+        trees = self._enrich_with_heights(tree_positions)
+
+        self._save_cache(cache_key, trees)
+        return trees
+
+    def _fetch_tree_positions(
+        self, rd_x: float, rd_y: float, radius: float
+    ) -> List[Dict[str, float]]:
+        """Fetch tree positions from BGT OGC API."""
+        try:
+            from pyproj import Transformer
+
+            transformer = Transformer.from_crs(
+                "EPSG:28992", "EPSG:4326", always_xy=True
+            )
+            lon_min, lat_min = transformer.transform(
+                rd_x - radius, rd_y - radius
+            )
+            lon_max, lat_max = transformer.transform(
+                rd_x + radius, rd_y + radius
+            )
+        except ImportError:
+            logger.error("pyproj not available for coordinate transformation")
+            return []
+
+        self._rate_limit()
+
+        try:
+            params = {
+                "bbox": f"{lon_min},{lat_min},{lon_max},{lat_max}",
+                "limit": 200,
+            }
+            response = self.session.get(
+                BGT_URL,
+                params=params,
+                headers={"User-Agent": random.choice(USER_AGENTS)},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            transformer_to_rd = Transformer.from_crs(
+                "EPSG:4326", "EPSG:28992", always_xy=True
+            )
+
+            positions = []
+            for feat in data.get("features", []):
+                props = feat.get("properties", {})
+                # Only include actual trees that still exist
+                plus_type = props.get("plus_type", "")
+                status = props.get("status", "")
+                if plus_type != "boom" or status != "bestaand":
+                    continue
+                # Skip trees with an end date (removed)
+                if props.get("termination_date"):
+                    continue
+
+                geom = feat.get("geometry", {})
+                coords = geom.get("coordinates", [])
+                if len(coords) >= 2:
+                    tree_rd_x, tree_rd_y = transformer_to_rd.transform(
+                        coords[0], coords[1]
+                    )
+                    positions.append(
+                        {"rd_x": round(tree_rd_x, 1), "rd_y": round(tree_rd_y, 1)}
+                    )
+
+            logger.info(f"BGT: {len(positions)} bomen gevonden in straal {radius}m")
+            return positions
+
+        except requests.RequestException as e:
+            logger.error(f"Error fetching BGT tree data: {e}")
+            return []
+
+    def _enrich_with_heights(
+        self, positions: List[Dict[str, float]]
+    ) -> List[Dict[str, Any]]:
+        """Get tree heights by querying AHN DSM and DTM."""
+        if not positions:
+            return []
+
+        # Batch: get a single AHN tile covering all trees
+        all_x = [p["rd_x"] for p in positions]
+        all_y = [p["rd_y"] for p in positions]
+        x_min, x_max = min(all_x) - 2, max(all_x) + 2
+        y_min, y_max = min(all_y) - 2, max(all_y) + 2
+
+        dsm_values = self._fetch_ahn_raster("dsm_05m", x_min, y_min, x_max, y_max)
+        dtm_values = self._fetch_ahn_raster("dtm_05m", x_min, y_min, x_max, y_max)
+
+        if dsm_values is None or dtm_values is None:
+            # Without AHN, estimate tree height as 8m (typical Dutch street tree)
+            logger.warning("AHN niet beschikbaar, schatting boomhoogte 8m")
+            return [
+                {"rd_x": p["rd_x"], "rd_y": p["rd_y"], "hoogte": 8.0}
+                for p in positions
+            ]
+
+        trees = []
+        ds_transform, ds_data = dsm_values
+        dt_transform, dt_data = dtm_values
+
+        for pos in positions:
+            dsm_h = self._sample_raster(ds_transform, ds_data, pos["rd_x"], pos["rd_y"])
+            dtm_h = self._sample_raster(dt_transform, dt_data, pos["rd_x"], pos["rd_y"])
+
+            if dsm_h is not None and dtm_h is not None:
+                height = dsm_h - dtm_h
+                if height > 1.0:  # Minimum tree height
+                    trees.append(
+                        {
+                            "rd_x": pos["rd_x"],
+                            "rd_y": pos["rd_y"],
+                            "hoogte": round(height, 1),
+                        }
+                    )
+            elif dsm_h is not None:
+                # DTM nodata (under building?), estimate ground from nearby
+                trees.append(
+                    {
+                        "rd_x": pos["rd_x"],
+                        "rd_y": pos["rd_y"],
+                        "hoogte": 8.0,  # fallback estimate
+                    }
+                )
+
+        logger.info(f"AHN: {len(trees)} bomen met hoogte bepaald")
+        return trees
+
+    def _fetch_ahn_raster(
+        self, coverage: str, x_min: float, y_min: float, x_max: float, y_max: float
+    ):
+        """Fetch AHN raster tile via WCS."""
+        try:
+            import numpy as np
+            import rasterio
+        except ImportError:
+            logger.error("rasterio/numpy not available for AHN parsing")
+            return None
+
+        self._rate_limit()
+
+        try:
+            url = (
+                f"{AHN_WCS_URL}?service=WCS&version=2.0.1"
+                f"&request=GetCoverage&CoverageId={coverage}"
+                f"&format=image/tiff"
+                f"&subset=x({x_min},{x_max})"
+                f"&subset=y({y_min},{y_max})"
+            )
+            response = self.session.get(
+                url,
+                headers={"User-Agent": random.choice(USER_AGENTS)},
+                timeout=30,
+            )
+            response.raise_for_status()
+
+            if "tiff" not in response.headers.get("content-type", ""):
+                return None
+
+            with rasterio.open(BytesIO(response.content)) as ds:
+                data = ds.read(1)
+                # Replace nodata with NaN
+                nodata_mask = data > 1e10
+                data = data.astype(np.float64)
+                data[nodata_mask] = np.nan
+                return (ds.transform, data)
+
+        except Exception as e:
+            logger.error(f"Error fetching AHN {coverage}: {e}")
+            return None
+
+    @staticmethod
+    def _sample_raster(transform, data, x: float, y: float) -> Optional[float]:
+        """Sample a raster value at a given RD coordinate."""
+        import numpy as np
+
+        try:
+            import rasterio
+
+            row, col = rasterio.transform.rowcol(transform, x, y)
+            if 0 <= row < data.shape[0] and 0 <= col < data.shape[1]:
+                val = data[row, col]
+                if not np.isnan(val):
+                    return float(val)
+        except Exception:
+            pass
+        return None
+
+    def _save_cache(self, cache_key: str, trees: List[Dict[str, Any]]) -> None:
+        if not self.cache_dir:
+            return
+        cache_path = self.cache_dir / f"{cache_key}.json"
+        try:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {"fetch_date": datetime.now().isoformat(), "trees": trees},
+                    f,
+                    ensure_ascii=False,
+                )
+        except IOError:
+            pass
+
+
+def create_bgt_boom_collector(
+    cache_dir: Optional[Path] = None,
+) -> BgtBoomCollector:
+    """Factory function to create a BGT boom collector."""
+    if cache_dir is None:
+        project_root = Path(__file__).parent.parent.parent
+        cache_dir = project_root / "data" / "cache" / "bgt_bomen"
+    return BgtBoomCollector(cache_dir=cache_dir)

--- a/backend/collectors/bgt_wegdeel_collector.py
+++ b/backend/collectors/bgt_wegdeel_collector.py
@@ -1,0 +1,251 @@
+"""
+BGT wegdeel collector voor voorkant-detectie.
+
+Haalt wegdeel-polygonen op uit de BGT (Basisregistratie Grootschalige
+Topografie) om te bepalen welke kant van een gebouw de straatkant is.
+Gebruikt voor tuinoriëntatie berekening.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+]
+
+BGT_WEGDEEL_URL = "https://api.pdok.nl/lv/bgt/ogc/v1/collections/wegdeel/items"
+
+# Relevante wegdeel functies voor voorkant-detectie
+RELEVANT_FUNCTIES = {
+    "rijbaan lokale weg",
+    "rijbaan regionale weg",
+    "woonerf",
+    "voetpad",
+    "inrit",
+}
+
+
+@dataclass
+class BgtWegdeelCollector:
+    """Collector voor BGT wegdeel-polygonen.
+
+    Haalt straten, voetpaden en inritten op om te bepalen welke kant
+    van een woning de straatkant (voorkant) is.
+    """
+
+    min_delay: float = 1.0
+    max_delay: float = 2.0
+    cache_dir: Optional[Path] = None
+    cache_days: int = 365
+    session: Optional[requests.Session] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+        if self.cache_dir:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _rate_limit(self) -> None:
+        now = time.perf_counter()
+        elapsed = now - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.perf_counter()
+
+    def get_roads(
+        self,
+        rd_x: float,
+        rd_y: float,
+        radius: float = 50.0,
+        use_cache: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Haal wegdeel-polygonen op rond een locatie.
+
+        Parameters
+        ----------
+        rd_x, rd_y : float
+            Middelpunt in RD-coördinaten (EPSG:28992)
+        radius : float
+            Zoekradius in meters (default: 50m)
+        use_cache : bool
+            Of gecachte resultaten gebruikt mogen worden
+
+        Returns
+        -------
+        list of dict
+            Elke dict bevat: polygon_coords (list of coord pairs in RD),
+            functie (str)
+        """
+        cache_key = f"wegdeel_{int(rd_x)}_{int(rd_y)}_{int(radius)}"
+
+        if use_cache and self.cache_dir:
+            cached = self._load_from_cache(cache_key)
+            if cached is not None:
+                return cached
+
+        roads = self._fetch_roads(rd_x, rd_y, radius)
+
+        self._save_to_cache(cache_key, roads)
+        return roads
+
+    def _fetch_roads(
+        self, rd_x: float, rd_y: float, radius: float
+    ) -> List[Dict[str, Any]]:
+        """Haal wegdelen op via BGT OGC API."""
+        try:
+            from pyproj import Transformer
+
+            transformer_to_wgs = Transformer.from_crs(
+                "EPSG:28992", "EPSG:4326", always_xy=True
+            )
+            lon_min, lat_min = transformer_to_wgs.transform(
+                rd_x - radius, rd_y - radius
+            )
+            lon_max, lat_max = transformer_to_wgs.transform(
+                rd_x + radius, rd_y + radius
+            )
+        except ImportError:
+            logger.error("pyproj niet beschikbaar voor coördinaattransformatie")
+            return []
+
+        self._rate_limit()
+
+        try:
+            params = {
+                "bbox": f"{lon_min},{lat_min},{lon_max},{lat_max}",
+                "limit": 200,
+            }
+            response = self.session.get(
+                BGT_WEGDEEL_URL,
+                params=params,
+                headers={"User-Agent": random.choice(USER_AGENTS)},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            transformer_to_rd = Transformer.from_crs(
+                "EPSG:4326", "EPSG:28992", always_xy=True
+            )
+
+            roads = []
+            for feat in data.get("features", []):
+                props = feat.get("properties", {})
+                functie = props.get("functie", "")
+                status = props.get("status", "")
+
+                if status != "bestaand":
+                    continue
+                if functie not in RELEVANT_FUNCTIES:
+                    continue
+
+                geom = feat.get("geometry", {})
+                geom_type = geom.get("type", "")
+                coords_raw = geom.get("coordinates", [])
+
+                if not coords_raw:
+                    continue
+
+                # Convert WGS84 polygon coords to RD
+                rd_coords = self._convert_polygon_to_rd(
+                    geom_type, coords_raw, transformer_to_rd
+                )
+                if rd_coords:
+                    roads.append({
+                        "polygon_coords": rd_coords,
+                        "functie": functie,
+                    })
+
+            logger.info(
+                f"BGT: {len(roads)} wegdelen gevonden in straal {radius}m"
+            )
+            return roads
+
+        except requests.RequestException as e:
+            logger.error(f"Error fetching BGT wegdeel data: {e}")
+            return []
+
+    @staticmethod
+    def _convert_polygon_to_rd(
+        geom_type: str,
+        coords_raw: list,
+        transformer,
+    ) -> Optional[List[List[float]]]:
+        """Convert GeoJSON polygon coordinates to RD."""
+        try:
+            if geom_type == "Polygon":
+                # coords_raw = [ring1, ring2, ...], ring = [[lon, lat], ...]
+                if not coords_raw or not coords_raw[0]:
+                    return None
+                exterior = coords_raw[0]
+                return [
+                    list(transformer.transform(c[0], c[1]))
+                    for c in exterior
+                ]
+            elif geom_type == "MultiPolygon":
+                # Take the first polygon (largest is typically the main one)
+                if not coords_raw or not coords_raw[0] or not coords_raw[0][0]:
+                    return None
+                exterior = coords_raw[0][0]
+                return [
+                    list(transformer.transform(c[0], c[1]))
+                    for c in exterior
+                ]
+        except (IndexError, TypeError, ValueError) as e:
+            logger.debug(f"Polygon conversie mislukt: {e}")
+        return None
+
+    def _load_from_cache(self, cache_key: str) -> Optional[List[Dict[str, Any]]]:
+        if not self.cache_dir:
+            return None
+        cache_path = self.cache_dir / f"{cache_key}.json"
+        if not cache_path.exists():
+            return None
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                cached = json.load(f)
+            cache_date = datetime.fromisoformat(cached.get("fetch_date", ""))
+            if datetime.now() - cache_date < timedelta(days=self.cache_days):
+                return cached.get("roads", [])
+        except (json.JSONDecodeError, ValueError, IOError):
+            pass
+        return None
+
+    def _save_to_cache(self, cache_key: str, roads: List[Dict[str, Any]]) -> None:
+        if not self.cache_dir:
+            return
+        cache_path = self.cache_dir / f"{cache_key}.json"
+        try:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(
+                    {"fetch_date": datetime.now().isoformat(), "roads": roads},
+                    f,
+                    ensure_ascii=False,
+                )
+        except IOError:
+            pass
+
+
+def create_bgt_wegdeel_collector(
+    cache_dir: Optional[Path] = None,
+) -> BgtWegdeelCollector:
+    """Factory function voor BGT wegdeel collector."""
+    if cache_dir is None:
+        project_root = Path(__file__).parent.parent.parent
+        cache_dir = project_root / "data" / "cache" / "bgt_wegdelen"
+    return BgtWegdeelCollector(cache_dir=cache_dir)

--- a/backend/collectors/driedbag_collector.py
+++ b/backend/collectors/driedbag_collector.py
@@ -542,6 +542,134 @@ class DrieDBagCollector:
         return buildings
 
 
+    def get_building_by_location(
+        self,
+        rd_x: float,
+        rd_y: float,
+        use_cache: bool = True,
+    ) -> Optional[DrieDBagResult]:
+        """Fetch building data using a spatial query instead of pand ID.
+
+        Useful when the pand_id maps to wrong coordinates in 3DBAG
+        (e.g. due to municipal mergers).
+
+        Parameters
+        ----------
+        rd_x, rd_y : float
+            Building location in RD coordinates (EPSG:28992)
+
+        Returns
+        -------
+        DrieDBagResult or None
+        """
+        cache_key = f"3dbag_loc_{int(rd_x)}_{int(rd_y)}"
+
+        if use_cache and self.cache_dir:
+            cache_path = self.cache_dir / f"{cache_key}.json"
+            if cache_path.exists():
+                try:
+                    with open(cache_path, "r", encoding="utf-8") as f:
+                        data = json.load(f)
+                    result = DrieDBagResult.from_dict(data)
+                    if datetime.now() - result.fetch_date < timedelta(days=self.cache_days):
+                        return result
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    pass
+
+        # Small bbox around point (15m)
+        radius = 15
+        bbox = f"{rd_x - radius},{rd_y - radius},{rd_x + radius},{rd_y + radius}"
+
+        try:
+            self._rate_limit()
+            url = f"{self.BASE_URL}?bbox={bbox}&limit=5"
+            logger.info(f"Fetching 3DBAG by location: bbox={bbox}")
+            response = self.session.get(
+                url,
+                headers=self._get_headers(),
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            metadata = data.get("metadata", {})
+            transform = metadata.get("transform", {})
+            if not transform:
+                transform = metadata.get("metadata", {}).get("transform", {})
+
+            # Find the building closest to our point
+            from shapely.geometry import Point
+            target = Point(rd_x, rd_y)
+            best_result = None
+            best_dist = float("inf")
+
+            for feature in data.get("features", []):
+                feat_verts = feature.get("vertices", [])
+                city_objects = feature.get("CityObjects", {})
+
+                for key, val in city_objects.items():
+                    if any(key.endswith(f"-{i}") for i in range(20)):
+                        continue
+
+                    attrs = val.get("attributes", {})
+                    pand_id = attrs.get("identificatie", key).replace(
+                        "NL.IMBAG.Pand.", ""
+                    )
+
+                    footprint = self._extract_footprint(val, feat_verts, transform) if feat_verts and transform else None
+                    if not footprint:
+                        continue
+
+                    from shapely.geometry import Polygon as ShapelyPoly
+                    fp_poly = ShapelyPoly(footprint)
+                    dist = target.distance(fp_poly)
+
+                    if dist < best_dist:
+                        best_dist = dist
+
+                        result = DrieDBagResult(pand_identificatie=pand_id)
+                        result.h_dak_max = attrs.get("b3_h_dak_max")
+                        result.h_dak_min = attrs.get("b3_h_dak_min")
+                        result.h_dak_50p = attrs.get("b3_h_dak_50p")
+                        result.h_dak_70p = attrs.get("b3_h_dak_70p")
+                        result.h_maaiveld = attrs.get("b3_h_maaiveld")
+                        result.dak_type = attrs.get("b3_dak_type")
+                        result.bouwlagen = attrs.get("b3_bouwlagen")
+                        result.opp_grond = attrs.get("b3_opp_grond")
+                        result.opp_dak_plat = attrs.get("b3_opp_dak_plat")
+                        result.opp_dak_schuin = attrs.get("b3_opp_dak_schuin")
+                        result.volume_lod22 = attrs.get("b3_volume_lod22")
+                        result.footprint_rd = footprint
+
+                        if result.h_dak_max is not None and result.h_maaiveld is not None:
+                            result.gebouwhoogte = round(result.h_dak_max - result.h_maaiveld, 2)
+
+                        # Roof orientation from child objects
+                        result.dak_delen = self._extract_roof_parts(city_objects)
+                        if result.dak_delen:
+                            result.dak_azimut, result.dak_hellingshoek = (
+                                self._compute_weighted_roof_orientation(result.dak_delen)
+                            )
+
+                        best_result = result
+
+            if best_result:
+                # Cache the result
+                if self.cache_dir:
+                    cache_path = self.cache_dir / f"{cache_key}.json"
+                    try:
+                        with open(cache_path, "w", encoding="utf-8") as f:
+                            json.dump(best_result.to_dict(), f, ensure_ascii=False, indent=2)
+                    except IOError:
+                        pass
+                return best_result
+
+        except Exception as e:
+            logger.error(f"Error fetching 3DBAG by location: {e}")
+
+        return None
+
+
 def create_driedbag_collector(cache_dir: Optional[Path] = None) -> DrieDBagCollector:
     """
     Factory function to create a 3DBAG collector with default cache directory.

--- a/backend/collectors/driedbag_collector.py
+++ b/backend/collectors/driedbag_collector.py
@@ -1,21 +1,23 @@
 """
-3DBAG collector for building height and roof data.
+3DBAG collector for building height, roof data, and orientation.
 
 Fetches 3D building attributes from api.3dbag.nl, including
-roof height, ground level, roof type, and building volume.
-Used for ceiling height estimation.
+roof height, ground level, roof type, building volume,
+roof orientation (azimuth), and building footprint geometry.
+Also supports spatial queries for surrounding buildings.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 import random
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -45,6 +47,10 @@ class DrieDBagResult:
     opp_dak_schuin: Optional[float] = None
     volume_lod22: Optional[float] = None
     gebouwhoogte: Optional[float] = None
+    dak_azimut: Optional[float] = None
+    dak_hellingshoek: Optional[float] = None
+    dak_delen: Optional[List[Dict[str, Any]]] = None
+    footprint_rd: Optional[List[List[float]]] = None
     fetch_date: datetime = field(default_factory=datetime.now)
     source: str = "3dbag.nl"
     error: Optional[str] = None
@@ -64,6 +70,10 @@ class DrieDBagResult:
             "opp_dak_schuin": self.opp_dak_schuin,
             "volume_lod22": self.volume_lod22,
             "gebouwhoogte": self.gebouwhoogte,
+            "dak_azimut": self.dak_azimut,
+            "dak_hellingshoek": self.dak_hellingshoek,
+            "dak_delen": self.dak_delen,
+            "footprint_rd": self.footprint_rd,
             "fetch_date": self.fetch_date.isoformat(),
             "source": self.source,
             "error": self.error,
@@ -91,6 +101,10 @@ class DrieDBagResult:
             opp_dak_schuin=data.get("opp_dak_schuin"),
             volume_lod22=data.get("volume_lod22"),
             gebouwhoogte=data.get("gebouwhoogte"),
+            dak_azimut=data.get("dak_azimut"),
+            dak_hellingshoek=data.get("dak_hellingshoek"),
+            dak_delen=data.get("dak_delen"),
+            footprint_rd=data.get("footprint_rd"),
             fetch_date=fetch_date,
             source=data.get("source", "3dbag.nl"),
             error=data.get("error"),
@@ -136,7 +150,7 @@ class DrieDBagCollector:
     def _get_headers(self) -> Dict[str, str]:
         return {
             "User-Agent": random.choice(USER_AGENTS),
-            "Accept": "application/city+json",
+            "Accept": "application/geo+json",
         }
 
     def _rate_limit(self) -> None:
@@ -269,9 +283,28 @@ class DrieDBagCollector:
             if result.h_dak_max is not None and result.h_maaiveld is not None:
                 result.gebouwhoogte = round(result.h_dak_max - result.h_maaiveld, 2)
 
+            # Extract roof orientation from child objects' semantic surfaces
+            result.dak_delen = self._extract_roof_parts(city_objects)
+            if result.dak_delen:
+                result.dak_azimut, result.dak_hellingshoek = (
+                    self._compute_weighted_roof_orientation(result.dak_delen)
+                )
+
+            # Extract footprint polygon in RD coordinates
+            metadata = data.get("metadata", {})
+            transform = metadata.get("transform", {})
+            if not transform:
+                transform = metadata.get("metadata", {}).get("transform", {})
+            vertices = feature.get("vertices", [])
+            if obj and vertices and transform:
+                result.footprint_rd = self._extract_footprint(
+                    obj, vertices, transform
+                )
+
             logger.info(
                 f"3DBAG data for {raw_id}: hoogte={result.gebouwhoogte}m, "
-                f"dak={result.dak_type}, bouwlagen={result.bouwlagen}"
+                f"dak={result.dak_type}, bouwlagen={result.bouwlagen}, "
+                f"azimut={result.dak_azimut}, footprint={'ja' if result.footprint_rd else 'nee'}"
             )
 
         except requests.RequestException as e:
@@ -282,6 +315,231 @@ class DrieDBagCollector:
             self._save_to_cache(result)
 
         return result
+
+
+    @staticmethod
+    def _extract_roof_parts(
+        city_objects: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Extract roof part orientations from child object semantic surfaces."""
+        roof_parts = []
+        for key, val in city_objects.items():
+            # Child objects have suffix like -0, -1, -2
+            if not any(key.endswith(f"-{i}") for i in range(20)):
+                continue
+            for geo in val.get("geometry", []):
+                if geo.get("lod") != "2.2":
+                    continue
+                surfaces = geo.get("semantics", {}).get("surfaces", [])
+                for surface in surfaces:
+                    if surface.get("type") != "RoofSurface":
+                        continue
+                    azimut = surface.get("b3_azimut")
+                    hellingshoek = surface.get("b3_hellingshoek")
+                    if azimut is not None:
+                        h_max = surface.get("b3_h_dak_max")
+                        h_min = surface.get("b3_h_dak_min")
+                        roof_parts.append(
+                            {
+                                "azimut": azimut,
+                                "hellingshoek": hellingshoek,
+                                "h_dak_max": h_max,
+                                "h_dak_min": h_min,
+                            }
+                        )
+        return roof_parts
+
+    @staticmethod
+    def _compute_weighted_roof_orientation(
+        roof_parts: List[Dict[str, Any]],
+    ) -> tuple[Optional[float], Optional[float]]:
+        """Compute area-weighted average roof azimuth and slope.
+
+        Uses circular mean for azimuth to handle the 0/360 wraparound.
+        Only considers sloped surfaces (hellingshoek > 5 degrees).
+        """
+        sin_sum = 0.0
+        cos_sum = 0.0
+        slope_sum = 0.0
+        count = 0
+
+        for part in roof_parts:
+            azimut = part.get("azimut")
+            hellingshoek = part.get("hellingshoek")
+            if azimut is None:
+                continue
+            # Only use meaningfully sloped surfaces for orientation
+            if hellingshoek is not None and hellingshoek > 5.0:
+                rad = math.radians(azimut)
+                sin_sum += math.sin(rad)
+                cos_sum += math.cos(rad)
+                slope_sum += hellingshoek
+                count += 1
+
+        if count == 0:
+            # No sloped surfaces; return first available azimuth as fallback
+            for part in roof_parts:
+                if part.get("azimut") is not None:
+                    avg_slope = part.get("hellingshoek")
+                    return round(part["azimut"], 1), (
+                        round(avg_slope, 1) if avg_slope else None
+                    )
+            return None, None
+
+        avg_azimut = math.degrees(math.atan2(sin_sum, cos_sum)) % 360
+        avg_slope = slope_sum / count
+        return round(avg_azimut, 1), round(avg_slope, 1)
+
+    @staticmethod
+    def _extract_footprint(
+        parent_obj: Dict[str, Any],
+        vertices: List[List[int]],
+        transform: Dict[str, Any],
+    ) -> Optional[List[List[float]]]:
+        """Convert CityJSON LoD 0 footprint vertices to RD coordinates."""
+        scale = transform.get("scale", [1, 1, 1])
+        translate = transform.get("translate", [0, 0, 0])
+
+        # Find LoD 0 geometry (footprint)
+        for geo in parent_obj.get("geometry", []):
+            if geo.get("lod") == "0":
+                boundaries = geo.get("boundaries", [])
+                if not boundaries or not boundaries[0]:
+                    continue
+                ring_indices = boundaries[0][0]
+                coords = []
+                for idx in ring_indices:
+                    if idx < len(vertices):
+                        v = vertices[idx]
+                        x = v[0] * scale[0] + translate[0]
+                        y = v[1] * scale[1] + translate[1]
+                        coords.append([round(x, 3), round(y, 3)])
+                if coords:
+                    return coords
+        return None
+
+    def get_surrounding_buildings(
+        self,
+        rd_x: float,
+        rd_y: float,
+        radius: float = 75.0,
+        exclude_pand_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fetch surrounding buildings within a bounding box.
+
+        Parameters
+        ----------
+        rd_x, rd_y : float
+            Center point in RD coordinates (EPSG:28992)
+        radius : float
+            Half-width of bounding box in meters (default: 75m)
+        exclude_pand_id : str, optional
+            Pand ID to exclude (the building itself)
+
+        Returns
+        -------
+        list of dict
+            Each dict has: pand_id, hoogte, footprint_rd
+        """
+        # Round bbox for cache key stability
+        bbox_key = (
+            f"{int(rd_x - radius)}_{int(rd_y - radius)}_"
+            f"{int(rd_x + radius)}_{int(rd_y + radius)}"
+        )
+
+        # Check cache
+        if self.cache_dir:
+            cache_path = self.cache_dir / f"3dbag_bbox_{bbox_key}.json"
+            if cache_path.exists():
+                try:
+                    with open(cache_path, "r", encoding="utf-8") as f:
+                        cached = json.load(f)
+                    cache_date = datetime.fromisoformat(cached.get("fetch_date", ""))
+                    if datetime.now() - cache_date < timedelta(days=30):
+                        buildings = cached.get("buildings", [])
+                        if exclude_pand_id:
+                            buildings = [
+                                b
+                                for b in buildings
+                                if b.get("pand_id") != exclude_pand_id
+                            ]
+                        return buildings
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+        bbox = f"{rd_x - radius},{rd_y - radius},{rd_x + radius},{rd_y + radius}"
+        buildings = []
+
+        try:
+            self._rate_limit()
+            url = f"{self.BASE_URL}?bbox={bbox}&limit=100"
+            logger.info(f"Fetching surrounding buildings: bbox={bbox}")
+            response = self.session.get(
+                url,
+                headers={"User-Agent": random.choice(USER_AGENTS), "Accept": "application/json"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            metadata = data.get("metadata", {})
+            transform = metadata.get("transform", {})
+            if not transform:
+                transform = metadata.get("metadata", {}).get("transform", {})
+
+            for feature in data.get("features", []):
+                feat_vertices = feature.get("vertices", [])
+                city_objects = feature.get("CityObjects", {})
+
+                for key, val in city_objects.items():
+                    # Skip child objects
+                    if any(key.endswith(f"-{i}") for i in range(20)):
+                        continue
+                    attrs = val.get("attributes", {})
+                    pand_id = attrs.get("identificatie", key).replace(
+                        "NL.IMBAG.Pand.", ""
+                    )
+                    h_max = attrs.get("b3_h_dak_max")
+                    h_mv = attrs.get("b3_h_maaiveld")
+                    hoogte = round(h_max - h_mv, 2) if h_max and h_mv else None
+
+                    footprint = None
+                    if feat_vertices and transform:
+                        footprint = self._extract_footprint(
+                            val, feat_vertices, transform
+                        )
+
+                    if hoogte and hoogte > 1.0:
+                        buildings.append(
+                            {
+                                "pand_id": pand_id,
+                                "hoogte": hoogte,
+                                "footprint_rd": footprint,
+                            }
+                        )
+
+        except requests.RequestException as e:
+            logger.error(f"Error fetching surrounding buildings: {e}")
+
+        # Save to cache
+        if self.cache_dir:
+            cache_path = self.cache_dir / f"3dbag_bbox_{bbox_key}.json"
+            try:
+                with open(cache_path, "w", encoding="utf-8") as f:
+                    json.dump(
+                        {"fetch_date": datetime.now().isoformat(), "buildings": buildings},
+                        f,
+                        ensure_ascii=False,
+                    )
+            except IOError:
+                pass
+
+        if exclude_pand_id:
+            buildings = [
+                b for b in buildings if b.get("pand_id") != exclude_pand_id
+            ]
+
+        return buildings
 
 
 def create_driedbag_collector(cache_dir: Optional[Path] = None) -> DrieDBagCollector:

--- a/backend/collectors/perceelgrens_collector.py
+++ b/backend/collectors/perceelgrens_collector.py
@@ -1,0 +1,323 @@
+"""
+Perceelgrens collector via PDOK Kadastrale Kaart WFS.
+
+Fetches cadastral parcel boundaries from the PDOK WFS service.
+Used to determine exact garden shape and area by subtracting
+the building footprint from the parcel polygon.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+]
+
+WFS_URL = "https://service.pdok.nl/kadaster/kadastralekaart/wfs/v5_0"
+
+
+@dataclass
+class PerceelgrensResult:
+    """Result from PDOK Kadastrale Kaart WFS lookup."""
+
+    perceel_polygon_rd: Optional[List[List[float]]] = None
+    perceeloppervlakte: Optional[float] = None
+    kadastrale_aanduiding: Optional[str] = None
+    fetch_date: datetime = field(default_factory=datetime.now)
+    source: str = "pdok_kadaster"
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "perceel_polygon_rd": self.perceel_polygon_rd,
+            "perceeloppervlakte": self.perceeloppervlakte,
+            "kadastrale_aanduiding": self.kadastrale_aanduiding,
+            "fetch_date": self.fetch_date.isoformat(),
+            "source": self.source,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PerceelgrensResult":
+        fetch_date = data.get("fetch_date")
+        if isinstance(fetch_date, str):
+            fetch_date = datetime.fromisoformat(fetch_date)
+        elif fetch_date is None:
+            fetch_date = datetime.now()
+
+        return cls(
+            perceel_polygon_rd=data.get("perceel_polygon_rd"),
+            perceeloppervlakte=data.get("perceeloppervlakte"),
+            kadastrale_aanduiding=data.get("kadastrale_aanduiding"),
+            fetch_date=fetch_date,
+            source=data.get("source", "pdok_kadaster"),
+            error=data.get("error"),
+        )
+
+
+@dataclass
+class PerceelgrensCollector:
+    """Collector for cadastral parcel boundaries from PDOK.
+
+    Uses the Kadastrale Kaart WFS v5_0 service which is free
+    and requires no API key.
+
+    Parameters
+    ----------
+    min_delay : float
+        Minimum delay between requests in seconds (default: 1.0)
+    max_delay : float
+        Maximum delay between requests in seconds (default: 2.0)
+    cache_dir : Path, optional
+        Directory for caching results
+    cache_days : int
+        Number of days to cache results (default: 90)
+    """
+
+    min_delay: float = 1.0
+    max_delay: float = 2.0
+    cache_dir: Optional[Path] = None
+    cache_days: int = 90
+    session: Optional[requests.Session] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+        if self.cache_dir:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _rate_limit(self) -> None:
+        now = time.perf_counter()
+        elapsed = now - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.perf_counter()
+
+    def _load_from_cache(self, cache_key: str) -> Optional[PerceelgrensResult]:
+        if not self.cache_dir:
+            return None
+        cache_path = self.cache_dir / f"{cache_key}.json"
+        if not cache_path.exists():
+            return None
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            result = PerceelgrensResult.from_dict(data)
+            if datetime.now() - result.fetch_date > timedelta(days=self.cache_days):
+                return None
+            return result
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return None
+
+    def _save_to_cache(self, cache_key: str, result: PerceelgrensResult) -> None:
+        if not self.cache_dir:
+            return
+        cache_path = self.cache_dir / f"{cache_key}.json"
+        try:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(result.to_dict(), f, ensure_ascii=False, indent=2)
+        except IOError:
+            pass
+
+    def get_perceel(
+        self,
+        rd_x: float,
+        rd_y: float,
+        building_footprint_rd: Optional[List[List[float]]] = None,
+        use_cache: bool = True,
+    ) -> PerceelgrensResult:
+        """Fetch the cadastral parcel containing a building.
+
+        Parameters
+        ----------
+        rd_x, rd_y : float
+            Building centroid in RD coordinates (EPSG:28992)
+        building_footprint_rd : list, optional
+            Building footprint polygon for matching the correct parcel
+        use_cache : bool
+            Whether to use cached results
+
+        Returns
+        -------
+        PerceelgrensResult
+            Parcel boundary polygon
+        """
+        cache_key = f"perceel_{int(rd_x)}_{int(rd_y)}"
+
+        if use_cache:
+            cached = self._load_from_cache(cache_key)
+            if cached:
+                return cached
+
+        result = PerceelgrensResult()
+        search_radius = 50  # meters
+
+        try:
+            self._rate_limit()
+
+            params = {
+                "service": "WFS",
+                "version": "2.0.0",
+                "request": "GetFeature",
+                "typeName": "kadastralekaart:Perceel",
+                "outputFormat": "application/json",
+                "count": 20,
+                "bbox": (
+                    f"{rd_x - search_radius},{rd_y - search_radius},"
+                    f"{rd_x + search_radius},{rd_y + search_radius},"
+                    "EPSG:28992"
+                ),
+            }
+
+            response = self.session.get(
+                WFS_URL,
+                params=params,
+                headers={"User-Agent": random.choice(USER_AGENTS)},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            features = data.get("features", [])
+            if not features:
+                result.error = "Geen percelen gevonden"
+                self._save_to_cache(cache_key, result)
+                return result
+
+            # Find the parcel that contains the building point
+            best_feature = self._find_matching_parcel(
+                features, rd_x, rd_y, building_footprint_rd
+            )
+
+            if best_feature:
+                geom = best_feature.get("geometry", {})
+                props = best_feature.get("properties", {})
+
+                # Extract polygon coordinates
+                coords = geom.get("coordinates", [])
+                if geom.get("type") == "Polygon" and coords:
+                    result.perceel_polygon_rd = [
+                        [round(c[0], 3), round(c[1], 3)] for c in coords[0]
+                    ]
+                elif geom.get("type") == "MultiPolygon" and coords:
+                    # Use the largest polygon
+                    largest = max(coords, key=lambda p: len(p[0]))
+                    result.perceel_polygon_rd = [
+                        [round(c[0], 3), round(c[1], 3)] for c in largest[0]
+                    ]
+
+                result.perceeloppervlakte = props.get("kadastraleGrootteWaarde")
+                sectie = props.get("sectie", "")
+                nummer = props.get("perceelnummer", "")
+                gemeente = props.get("kadastraleGemeenteWaarde", "")
+                if sectie and nummer:
+                    result.kadastrale_aanduiding = f"{gemeente} {sectie} {nummer}"
+
+                logger.info(
+                    f"Perceel gevonden: {result.kadastrale_aanduiding}, "
+                    f"opp={result.perceeloppervlakte}m²"
+                )
+            else:
+                result.error = "Geen passend perceel gevonden voor gebouw"
+
+        except requests.RequestException as e:
+            logger.error(f"Error fetching perceel data: {e}")
+            result.error = f"Fout bij ophalen perceeldata: {str(e)}"
+
+        self._save_to_cache(cache_key, result)
+        return result
+
+    @staticmethod
+    def _find_matching_parcel(
+        features: List[Dict[str, Any]],
+        rd_x: float,
+        rd_y: float,
+        building_footprint_rd: Optional[List[List[float]]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Find the parcel that contains the building.
+
+        Uses shapely for point-in-polygon and intersection tests.
+        Falls back to nearest parcel if no containment match.
+        """
+        try:
+            from shapely.geometry import Point, Polygon, shape
+
+            point = Point(rd_x, rd_y)
+
+            # Try point-in-polygon first
+            for feat in features:
+                geom = feat.get("geometry")
+                if not geom:
+                    continue
+                try:
+                    poly = shape(geom)
+                    if poly.contains(point):
+                        return feat
+                except Exception:
+                    continue
+
+            # If building footprint provided, try intersection
+            if building_footprint_rd:
+                building_poly = Polygon(building_footprint_rd)
+                best_overlap = 0.0
+                best_feat = None
+                for feat in features:
+                    geom = feat.get("geometry")
+                    if not geom:
+                        continue
+                    try:
+                        poly = shape(geom)
+                        overlap = poly.intersection(building_poly).area
+                        if overlap > best_overlap:
+                            best_overlap = overlap
+                            best_feat = feat
+                    except Exception:
+                        continue
+                if best_feat:
+                    return best_feat
+
+            # Fallback: nearest parcel centroid
+            best_dist = float("inf")
+            best_feat = None
+            for feat in features:
+                geom = feat.get("geometry")
+                if not geom:
+                    continue
+                try:
+                    poly = shape(geom)
+                    dist = point.distance(poly.centroid)
+                    if dist < best_dist:
+                        best_dist = dist
+                        best_feat = feat
+                except Exception:
+                    continue
+            return best_feat
+
+        except ImportError:
+            # Without shapely, return the first feature
+            return features[0] if features else None
+
+
+def create_perceelgrens_collector(
+    cache_dir: Optional[Path] = None,
+) -> PerceelgrensCollector:
+    """Factory function to create a perceelgrens collector."""
+    if cache_dir is None:
+        project_root = Path(__file__).parent.parent.parent
+        cache_dir = project_root / "data" / "cache" / "perceel"
+    return PerceelgrensCollector(cache_dir=cache_dir)

--- a/backend/services/orientatie.py
+++ b/backend/services/orientatie.py
@@ -51,6 +51,7 @@ class OrientatieResult:
     funda_tuin_oppervlakte: Optional[int] = None
 
     # Meta
+    tuin_oppervlakte_bron: Optional[str] = None  # "funda" of "schatting"
     methode: Optional[str] = None
     betrouwbaarheid: Optional[str] = None
     details: Optional[str] = None
@@ -987,7 +988,6 @@ def bereken_orientatie(
     )
     result.tuin_orientatie = tuin_label
     result.tuin_azimut = tuin_az
-    result.tuin_oppervlakte_berekend = tuin_opp
 
     # Funda vergelijking
     if funda_tuin_orientatie:
@@ -995,6 +995,24 @@ def bereken_orientatie(
         result.funda_tuin_orientatie = parsed_label
     if funda_tuin_oppervlakte:
         result.funda_tuin_oppervlakte = funda_tuin_oppervlakte
+
+    # Hybride tuinoppervlakte: Funda primair, eigen schatting als fallback
+    if funda_tuin_oppervlakte and funda_tuin_oppervlakte > 0:
+        result.tuin_oppervlakte_berekend = float(funda_tuin_oppervlakte)
+        result.tuin_oppervlakte_bron = "funda"
+    elif tuin_opp is not None and tuin_opp > 0:
+        # Bij grote percelen (>400m²): schatting te onbetrouwbaar
+        from shapely.geometry import Polygon as _Polygon
+        if perceel_polygon_rd:
+            _perc = _Polygon(perceel_polygon_rd)
+            if _perc.is_valid and _perc.area > 400:
+                result.tuin_oppervlakte_berekend = None
+            else:
+                result.tuin_oppervlakte_berekend = tuin_opp
+                result.tuin_oppervlakte_bron = "schatting"
+        else:
+            result.tuin_oppervlakte_berekend = tuin_opp
+            result.tuin_oppervlakte_bron = "schatting"
 
     if road_polygons:
         methode_parts.append("BGT")

--- a/backend/services/orientatie.py
+++ b/backend/services/orientatie.py
@@ -286,11 +286,12 @@ def bepaal_tuin_orientatie(
         elif front_methode in ("voetpad", "rijbaan", "inrit"):
             betrouwbaarheid = "middel"
 
-    # Stap 3: Tuinoppervlakte berekenen (splits perceel in voor/achter)
+    # Stap 3: Tuinoppervlakte berekenen via ray-methode
     tuin_opp = None
     if building_footprint_rd and perceel_polygon_rd and tuin_az is not None:
         tuin_opp = _bereken_tuin_oppervlakte(
-            building_footprint_rd, perceel_polygon_rd, tuin_az
+            building_footprint_rd, perceel_polygon_rd, tuin_az,
+            rd_x=rd_x, rd_y=rd_y,
         )
 
     # Fallback: Funda oriëntatie als BGT geen resultaat geeft
@@ -308,16 +309,24 @@ def _bereken_tuin_oppervlakte(
     building_footprint_rd: List[List[float]],
     perceel_polygon_rd: List[List[float]],
     tuin_azimut: float,
+    rd_x: float = 0.0,
+    rd_y: float = 0.0,
 ) -> Optional[float]:
-    """Bereken tuinoppervlakte door perceel te splitsen in voor/achter.
+    """Bereken tuinoppervlakte via proportionele verdeling.
 
-    Splitst de open ruimte (perceel - gebouw) met een lijn loodrecht
-    op de voor-achter-as door het gebouw-centroid. De helft in de
-    tuin-richting = tuinoppervlakte.
+    Splits de open ruimte (perceel_opp - building_opp) in voor/achter
+    op basis van de relatieve afstanden vanuit het perceel-centroid
+    naar de perceelrand in tuin- en frontrichting.
+
+    Dit is robuuster dan ray-rectangle of perceel.difference(building)
+    omdat het niet afhankelijk is van building-perceel overlap
+    (3DBAG en Kadaster coördinaten liggen vaak verschoven).
     """
+    MAX_TUIN_M2 = 500
+    DEFAULT_ACHTER_FRACTIE = 0.60  # Typisch NL rijtjeshuis
+
     try:
-        from shapely.geometry import LineString, MultiPolygon, Polygon
-        from shapely.ops import split
+        from shapely.geometry import LineString, Polygon
 
         building = Polygon(building_footprint_rd)
         perceel = Polygon(perceel_polygon_rd)
@@ -327,53 +336,56 @@ def _bereken_tuin_oppervlakte(
         if not perceel.is_valid:
             perceel = perceel.buffer(0)
 
-        open_ruimte = perceel.difference(building)
-        if open_ruimte.is_empty or open_ruimte.area < 1.0:
+        perceel_opp = perceel.area
+        building_opp = building.area
+
+        # Corrigeer te kleine footprints (puntlocatie i.p.v. echt gebouw)
+        if building_opp < 20:
+            building_opp = 55  # Gemiddeld NL rijtjeshuis
+
+        open_ruimte = max(0, perceel_opp - building_opp)
+        if open_ruimte < 1.0:
             return 0.0
 
-        # Splitlijn: loodrecht op de voor-achter-as door building centroid
-        bld_cx, bld_cy = building.centroid.x, building.centroid.y
+        # Bij grote percelen (>400m²): waarschijnlijk VvE/gedeeld/appartement.
+        # Cap open ruimte op basis van een geschatte individuele footprint.
+        if perceel_opp > 400:
+            eff_footprint = min(building_opp, 80)
+            max_open = eff_footprint * 2.5
+            if open_ruimte > max_open:
+                open_ruimte = max_open
 
-        # Richting loodrecht op tuin-azimut (= loodrecht op voor-achter-as)
-        perp_az = math.radians((tuin_azimut + 90) % 360)
-        line_len = 100.0  # Ruim genoeg om perceel te doorkruisen
-        x1 = bld_cx + math.sin(perp_az) * line_len
-        y1 = bld_cy + math.cos(perp_az) * line_len
-        x2 = bld_cx - math.sin(perp_az) * line_len
-        y2 = bld_cy - math.cos(perp_az) * line_len
+        # Meet voor/achter-afstanden vanuit perceel centroid
+        cx, cy = perceel.centroid.x, perceel.centroid.y
 
-        split_line = LineString([(x1, y1), (x2, y2)])
+        def _ray_dist(dir_az):
+            rad = math.radians(dir_az)
+            ray = LineString([
+                (cx, cy),
+                (cx + math.sin(rad) * 200, cy + math.cos(rad) * 200),
+            ])
+            inter = ray.intersection(perceel.boundary)
+            if inter.is_empty:
+                return None
+            if inter.geom_type == "Point":
+                return math.hypot(inter.x - cx, inter.y - cy)
+            return min(
+                math.hypot(p.x - cx, p.y - cy)
+                for p in inter.geoms
+            )
 
-        # Split de open ruimte
-        try:
-            parts = split(open_ruimte, split_line)
-        except Exception:
-            # Als split faalt, geef totale open ruimte
-            return round(open_ruimte.area, 1)
+        tuin_dist = _ray_dist(tuin_azimut)
+        front_dist = _ray_dist((tuin_azimut + 180) % 360)
 
-        if len(parts.geoms) < 2:
-            return round(open_ruimte.area, 1)
+        if (tuin_dist is not None and front_dist is not None
+                and (tuin_dist + front_dist) > 1.0):
+            achter_fractie = tuin_dist / (tuin_dist + front_dist)
+        else:
+            achter_fractie = DEFAULT_ACHTER_FRACTIE
 
-        # Bepaal welke helft de tuin-kant is
-        tuin_rad = math.radians(tuin_azimut)
-        ref_x = bld_cx + math.sin(tuin_rad) * 20
-        ref_y = bld_cy + math.cos(tuin_rad) * 20
+        tuin_opp = min(open_ruimte * achter_fractie, MAX_TUIN_M2)
 
-        # De helft waarvan het centroid het dichtst bij het tuin-referentiepunt ligt
-        best_part = None
-        best_dist = float("inf")
-        for part in parts.geoms:
-            if part.is_empty:
-                continue
-            cx, cy = part.centroid.x, part.centroid.y
-            dist = math.hypot(cx - ref_x, cy - ref_y)
-            if dist < best_dist:
-                best_dist = dist
-                best_part = part
-
-        if best_part:
-            return round(best_part.area, 1)
-        return round(open_ruimte.area, 1)
+        return round(tuin_opp, 1)
 
     except Exception as e:
         logger.warning(f"Fout bij tuinoppervlakte berekening: {e}")

--- a/backend/services/orientatie.py
+++ b/backend/services/orientatie.py
@@ -1,0 +1,742 @@
+"""
+Oriëntatie en schaduwanalyse service.
+
+Berekent tuinoriëntatie, zonuren (incl. schaduw van eigen gebouw,
+buurtgebouwen en bomen), en zonnepanelen geschiktheid.
+
+Databronnen: 3DBAG, PDOK Kadaster, BGT, AHN.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OrientatieResult:
+    """Complete oriëntatie- en zonanalyse resultaat."""
+
+    # Tuinoriëntatie
+    tuin_orientatie: Optional[str] = None
+    tuin_azimut: Optional[float] = None
+    tuin_oppervlakte_berekend: Optional[float] = None
+
+    # Zonuren (incl. schaduwcorrectie)
+    zon_uren_zomer: Optional[float] = None
+    zon_uren_lente: Optional[float] = None
+    zon_uren_winter: Optional[float] = None
+    zon_label: Optional[str] = None
+
+    # Schaduwanalyse
+    schaduw_eigen_gebouw: Optional[str] = None
+    schaduw_buren: Optional[str] = None
+    schaduw_bomen: Optional[str] = None
+    effectieve_tuin_diepte: Optional[float] = None
+
+    # Zonnepanelen
+    zonnepanelen_score: Optional[int] = None
+    zonnepanelen_label: Optional[str] = None
+    dak_orientatie: Optional[str] = None
+    dak_hellingshoek: Optional[float] = None
+    geschikt_dakoppervlak: Optional[float] = None
+
+    # Meta
+    methode: Optional[str] = None
+    betrouwbaarheid: Optional[str] = None
+    details: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
+# --- Zonnestand berekening ---
+
+def bereken_zonnestand(uur: float, dag_van_jaar: int, latitude: float = 52.0) -> tuple[float, float]:
+    """Bereken zonazimut en zonhoogte voor een gegeven tijdstip.
+
+    Parameters
+    ----------
+    uur : float
+        Uur van de dag in UTC+2 (zomertijd), bijv. 14.5 = 14:30
+    dag_van_jaar : int
+        Dag van het jaar (1-365), bijv. 172 = 21 juni
+    latitude : float
+        Breedtegraad in graden (default: 52.0 voor Nederland)
+
+    Returns
+    -------
+    tuple of (azimut, hoogte) in graden
+        azimut: 0=Noord, 90=Oost, 180=Zuid, 270=West
+        hoogte: graden boven horizon (negatief = onder horizon)
+    """
+    lat_rad = math.radians(latitude)
+
+    # Zonsdeclinatie (Cooper formule)
+    declinatie = 23.45 * math.sin(math.radians(360 * (284 + dag_van_jaar) / 365))
+    dec_rad = math.radians(declinatie)
+
+    # Uurhoek (solar hour angle): 12:00 UTC+2 ≈ 12:00 solar time voor NL
+    # Correctie voor tijdzone: NL is ~5° oost, UTC+2 zomertijd
+    solar_hour = uur - 2.0 + (5.0 / 15.0)  # correctie naar solar time
+    hour_angle = math.radians((solar_hour - 12.0) * 15.0)
+
+    # Zonhoogte (altitude)
+    sin_alt = (
+        math.sin(lat_rad) * math.sin(dec_rad)
+        + math.cos(lat_rad) * math.cos(dec_rad) * math.cos(hour_angle)
+    )
+    altitude = math.degrees(math.asin(max(-1, min(1, sin_alt))))
+
+    # Zonazimut
+    cos_az = (
+        math.sin(dec_rad) - math.sin(lat_rad) * sin_alt
+    ) / max(math.cos(lat_rad) * math.cos(math.radians(altitude)), 1e-10)
+    cos_az = max(-1, min(1, cos_az))
+    azimut = math.degrees(math.acos(cos_az))
+
+    # Correctie: azimut is van zuid, omrekenen naar noord
+    if hour_angle > 0:
+        azimut = 360 - azimut
+
+    return round(azimut, 1), round(altitude, 1)
+
+
+# --- Kompasrichting ---
+
+KOMPAS_RICHTINGEN = [
+    (0, "Noord"), (45, "Noordoost"), (90, "Oost"), (135, "Zuidoost"),
+    (180, "Zuid"), (225, "Zuidwest"), (270, "West"), (315, "Noordwest"),
+]
+
+
+def azimut_naar_kompas(azimut: float) -> str:
+    """Converteer azimut (graden) naar 8-punt kompasrichting."""
+    azimut = azimut % 360
+    best_label = "Noord"
+    best_diff = 360
+    for angle, label in KOMPAS_RICHTINGEN:
+        diff = abs(azimut - angle)
+        if diff > 180:
+            diff = 360 - diff
+        if diff < best_diff:
+            best_diff = diff
+            best_label = label
+    return best_label
+
+
+# --- Tuinoriëntatie ---
+
+def bepaal_tuin_orientatie(
+    building_footprint_rd: Optional[List[List[float]]],
+    perceel_polygon_rd: Optional[List[List[float]]],
+    funda_tuin_orientatie: Optional[str] = None,
+) -> tuple[Optional[str], Optional[float], Optional[float]]:
+    """Bepaal tuinoriëntatie op basis van perceelgrens en gebouw-footprint.
+
+    Returns (orientatie_label, azimut, tuin_oppervlakte)
+    """
+    if building_footprint_rd and perceel_polygon_rd:
+        try:
+            from shapely.geometry import MultiPolygon, Polygon
+
+            building = Polygon(building_footprint_rd)
+            perceel = Polygon(perceel_polygon_rd)
+
+            if not building.is_valid:
+                building = building.buffer(0)
+            if not perceel.is_valid:
+                perceel = perceel.buffer(0)
+
+            tuin = perceel.difference(building)
+            tuin_opp = round(tuin.area, 1)
+
+            if tuin_opp < 1.0:
+                return None, None, 0.0
+
+            # Bepaal tuinoriëntatie: richting van gebouw-centroid naar tuin-centroid
+            bld_cx, bld_cy = building.centroid.x, building.centroid.y
+
+            # Voor MultiPolygon (L-vormige tuinen bij hoekwoningen):
+            # gebruik het grootste deel
+            if isinstance(tuin, MultiPolygon):
+                tuin_parts = list(tuin.geoms)
+                tuin_main = max(tuin_parts, key=lambda p: p.area)
+            else:
+                tuin_main = tuin
+
+            tuin_cx, tuin_cy = tuin_main.centroid.x, tuin_main.centroid.y
+
+            # Vector van gebouw naar tuin
+            dx = tuin_cx - bld_cx
+            dy = tuin_cy - bld_cy
+
+            # Azimut: 0=Noord, 90=Oost, 180=Zuid, 270=West
+            azimut = (math.degrees(math.atan2(dx, dy)) + 360) % 360
+            label = azimut_naar_kompas(azimut)
+
+            return label, round(azimut, 1), tuin_opp
+
+        except Exception as e:
+            logger.warning(f"Fout bij tuinoriëntatie berekening: {e}")
+
+    # Fallback: parse Funda tuin_orientatie
+    if funda_tuin_orientatie:
+        return _parse_funda_orientatie(funda_tuin_orientatie)
+
+    return None, None, None
+
+
+def _parse_funda_orientatie(
+    text: str,
+) -> tuple[Optional[str], Optional[float], Optional[float]]:
+    """Parse Funda tuin_orientatie string naar richting en azimut."""
+    text_lower = text.lower()
+
+    richting_map = {
+        "noord": 0, "noordoost": 45, "oost": 90, "zuidoost": 135,
+        "zuid": 180, "zuidwest": 225, "west": 270, "noordwest": 315,
+        "noorden": 0, "noordoosten": 45, "oosten": 90, "zuidoosten": 135,
+        "zuiden": 180, "zuidwesten": 225, "westen": 270, "noordwesten": 315,
+    }
+
+    for richting, azimut in sorted(richting_map.items(), key=lambda x: -len(x[0])):
+        if richting in text_lower:
+            label = azimut_naar_kompas(azimut)
+            return label, float(azimut), None
+
+    return None, None, None
+
+
+# --- Schaduwberekening ---
+
+def _schaduw_lengte(hoogte: float, zon_altitude: float) -> float:
+    """Bereken schaduwlengte gegeven objecthoogte en zonhoogte."""
+    if zon_altitude <= 0:
+        return 999.0  # zon onder horizon
+    return hoogte / math.tan(math.radians(zon_altitude))
+
+
+def _schaduw_richting(zon_azimut: float) -> float:
+    """Schaduw valt in tegengestelde richting van de zon."""
+    return (zon_azimut + 180) % 360
+
+
+def bereken_schaduw_op_punt(
+    punt_x: float,
+    punt_y: float,
+    schaduwwerpers: List[Dict[str, Any]],
+    zon_azimut: float,
+    zon_altitude: float,
+) -> bool:
+    """Check of een punt in de schaduw ligt van enig object.
+
+    Parameters
+    ----------
+    punt_x, punt_y : float
+        Punt om te checken (RD)
+    schaduwwerpers : list of dict
+        Elk met: x, y, hoogte, (optioneel: footprint_rd)
+    zon_azimut, zon_altitude : float
+        Huidige zonstand
+
+    Returns
+    -------
+    bool
+        True als het punt in de schaduw ligt
+    """
+    if zon_altitude <= 2:
+        return True  # Zon te laag, effectief geen zon
+
+    schaduw_len_per_m = 1.0 / math.tan(math.radians(zon_altitude))
+    # Schaduwrichting als dx, dy per meter hoogte
+    schaduw_az = math.radians(_schaduw_richting(zon_azimut))
+    dx_per_m = math.sin(schaduw_az) * schaduw_len_per_m
+    dy_per_m = math.cos(schaduw_az) * schaduw_len_per_m
+
+    for obj in schaduwwerpers:
+        hoogte = obj.get("hoogte", 0)
+        if hoogte < 1.5:
+            continue
+
+        footprint = obj.get("footprint_rd")
+        if footprint and len(footprint) >= 3:
+            # Voor gebouwen: check of het punt in de schaduwprojectie ligt
+            if _punt_in_gebouwschaduw(
+                punt_x, punt_y, footprint, hoogte, zon_azimut, zon_altitude
+            ):
+                return True
+        else:
+            # Voor bomen (puntobjecten): simplere check
+            obj_x = obj.get("rd_x", obj.get("x", 0))
+            obj_y = obj.get("rd_y", obj.get("y", 0))
+            schaduw_tip_x = obj_x + dx_per_m * hoogte
+            schaduw_tip_y = obj_y + dy_per_m * hoogte
+
+            # Check of punt binnen ~3m van de schaduwlijn ligt (boomkruin)
+            kruin_radius = min(hoogte * 0.4, 5.0)  # Kruin ~40% van hoogte
+            if _punt_nabij_lijn(
+                punt_x, punt_y, obj_x, obj_y,
+                schaduw_tip_x, schaduw_tip_y, kruin_radius
+            ):
+                return True
+
+    return False
+
+
+def _punt_in_gebouwschaduw(
+    px: float,
+    py: float,
+    footprint: List[List[float]],
+    hoogte: float,
+    zon_azimut: float,
+    zon_altitude: float,
+) -> bool:
+    """Check of een punt in de schaduw van een gebouw ligt."""
+    try:
+        from shapely.geometry import Point, Polygon
+        from shapely.affinity import translate
+
+        gebouw = Polygon(footprint)
+        if not gebouw.is_valid:
+            gebouw = gebouw.buffer(0)
+
+        schaduw_len = _schaduw_lengte(hoogte, zon_altitude)
+        schaduw_az = math.radians(_schaduw_richting(zon_azimut))
+        dx = math.sin(schaduw_az) * schaduw_len
+        dy = math.cos(schaduw_az) * schaduw_len
+
+        # Schaduwpolygon = unie van origineel gebouw en verschoven gebouw
+        verschoven = translate(gebouw, xoff=dx, yoff=dy)
+        schaduw_poly = gebouw.union(verschoven).convex_hull
+
+        return schaduw_poly.contains(Point(px, py))
+    except Exception:
+        return False
+
+
+def _punt_nabij_lijn(
+    px: float, py: float,
+    x1: float, y1: float,
+    x2: float, y2: float,
+    max_afstand: float,
+) -> bool:
+    """Check of een punt binnen max_afstand van een lijnstuk ligt."""
+    dx = x2 - x1
+    dy = y2 - y1
+    len_sq = dx * dx + dy * dy
+    if len_sq < 0.01:
+        return math.hypot(px - x1, py - y1) <= max_afstand
+
+    t = max(0, min(1, ((px - x1) * dx + (py - y1) * dy) / len_sq))
+    proj_x = x1 + t * dx
+    proj_y = y1 + t * dy
+    dist = math.hypot(px - proj_x, py - proj_y)
+    return dist <= max_afstand
+
+
+# --- Zonuren berekening ---
+
+def bereken_zon_uren(
+    tuin_centroid_x: float,
+    tuin_centroid_y: float,
+    building_footprint_rd: Optional[List[List[float]]],
+    gebouwhoogte: float,
+    buurtgebouwen: List[Dict[str, Any]],
+    bomen: List[Dict[str, Any]],
+    latitude: float = 52.0,
+) -> Dict[str, Any]:
+    """Bereken zonuren voor zomer, lente en winter incl. schaduwanalyse.
+
+    Returns dict met zon_uren_zomer, zon_uren_lente, zon_uren_winter, label,
+    schaduw_eigen_gebouw, schaduw_buren, schaduw_bomen.
+    """
+    # Bouw lijst van alle schaduwwerpers
+    schaduwwerpers = []
+
+    # Eigen gebouw
+    if building_footprint_rd and gebouwhoogte:
+        schaduwwerpers.append({
+            "footprint_rd": building_footprint_rd,
+            "hoogte": gebouwhoogte,
+            "type": "eigen",
+        })
+
+    # Buurtgebouwen
+    for buur in buurtgebouwen:
+        if buur.get("hoogte") and buur.get("hoogte") > 2.0:
+            schaduwwerpers.append({
+                "footprint_rd": buur.get("footprint_rd"),
+                "hoogte": buur["hoogte"],
+                "rd_x": _centroid_x(buur.get("footprint_rd")),
+                "rd_y": _centroid_y(buur.get("footprint_rd")),
+                "type": "buur",
+            })
+
+    # Bomen
+    for boom in bomen:
+        schaduwwerpers.append({
+            "rd_x": boom["rd_x"],
+            "rd_y": boom["rd_y"],
+            "hoogte": boom["hoogte"],
+            "type": "boom",
+        })
+
+    # Referentiedagen: zomer (172), lente (80), winter (355)
+    dagen = {"zomer": 172, "lente": 80, "winter": 355}
+    resultaat = {}
+
+    schaduw_eigen_uren = {"zomer": 0, "lente": 0, "winter": 0}
+    schaduw_buren_uren = {"zomer": 0, "lente": 0, "winter": 0}
+    schaduw_bomen_uren = {"zomer": 0, "lente": 0, "winter": 0}
+
+    for seizoen, dag in dagen.items():
+        zon_uren = 0.0
+        tijdstappen = 0
+
+        for half_uur in range(10, 44):  # 5:00 - 22:00 (UTC+2)
+            uur = half_uur / 2.0
+            az, alt = bereken_zonnestand(uur, dag, latitude)
+
+            if alt <= 2:
+                continue
+
+            tijdstappen += 1
+
+            # Check schaduw per type
+            in_schaduw = False
+            in_eigen = bereken_schaduw_op_punt(
+                tuin_centroid_x, tuin_centroid_y,
+                [s for s in schaduwwerpers if s["type"] == "eigen"],
+                az, alt,
+            )
+            in_buren = bereken_schaduw_op_punt(
+                tuin_centroid_x, tuin_centroid_y,
+                [s for s in schaduwwerpers if s["type"] == "buur"],
+                az, alt,
+            )
+            in_bomen = bereken_schaduw_op_punt(
+                tuin_centroid_x, tuin_centroid_y,
+                [s for s in schaduwwerpers if s["type"] == "boom"],
+                az, alt,
+            )
+
+            if in_eigen:
+                schaduw_eigen_uren[seizoen] += 0.5
+            if in_buren:
+                schaduw_buren_uren[seizoen] += 0.5
+            if in_bomen:
+                schaduw_bomen_uren[seizoen] += 0.5
+
+            if in_eigen or in_buren or in_bomen:
+                in_schaduw = True
+
+            if not in_schaduw:
+                zon_uren += 0.5
+
+        resultaat[f"zon_uren_{seizoen}"] = round(zon_uren, 1)
+
+    # Bepaal label op basis van zomerzonuren
+    zomer_uren = resultaat.get("zon_uren_zomer", 0)
+    if zomer_uren >= 6:
+        resultaat["zon_label"] = "Veel zon"
+    elif zomer_uren >= 4:
+        resultaat["zon_label"] = "Gemiddeld"
+    else:
+        resultaat["zon_label"] = "Weinig zon"
+
+    # Schaduw-beschrijvingen
+    resultaat["schaduw_eigen_gebouw"] = _beschrijf_eigen_schaduw(
+        gebouwhoogte, schaduw_eigen_uren
+    )
+    resultaat["schaduw_buren"] = _beschrijf_buren_schaduw(
+        buurtgebouwen, schaduw_buren_uren, tuin_centroid_x, tuin_centroid_y
+    )
+    resultaat["schaduw_bomen"] = _beschrijf_bomen_schaduw(
+        bomen, schaduw_bomen_uren, tuin_centroid_x, tuin_centroid_y
+    )
+
+    # Effectieve tuindiepte: schaduwlengte eigen gebouw bij zomermiddag
+    if gebouwhoogte:
+        _, alt_zomer = bereken_zonnestand(13.0, 172, latitude)
+        if alt_zomer > 0:
+            resultaat["effectieve_tuin_diepte"] = round(
+                _schaduw_lengte(gebouwhoogte, alt_zomer), 1
+            )
+
+    return resultaat
+
+
+def _centroid_x(footprint: Optional[List[List[float]]]) -> float:
+    if not footprint:
+        return 0.0
+    return sum(p[0] for p in footprint) / len(footprint)
+
+
+def _centroid_y(footprint: Optional[List[List[float]]]) -> float:
+    if not footprint:
+        return 0.0
+    return sum(p[1] for p in footprint) / len(footprint)
+
+
+def _beschrijf_eigen_schaduw(
+    hoogte: Optional[float], uren: Dict[str, float]
+) -> Optional[str]:
+    if not hoogte or uren["zomer"] < 0.5:
+        return None
+    return (
+        f"Eigen gebouw ({hoogte:.0f}m) veroorzaakt "
+        f"{uren['zomer']:.0f}u schaduw in zomer, "
+        f"{uren['winter']:.0f}u in winter"
+    )
+
+
+def _beschrijf_buren_schaduw(
+    buurtgebouwen: List[Dict[str, Any]],
+    uren: Dict[str, float],
+    tuin_x: float,
+    tuin_y: float,
+) -> Optional[str]:
+    if uren["zomer"] < 0.5:
+        return None
+
+    # Vind dichtstbijzijnde hoge buur
+    closest = None
+    closest_dist = float("inf")
+    for buur in buurtgebouwen:
+        fp = buur.get("footprint_rd")
+        if not fp or buur.get("hoogte", 0) < 5:
+            continue
+        bx = _centroid_x(fp)
+        by = _centroid_y(fp)
+        dist = math.hypot(bx - tuin_x, by - tuin_y)
+        if dist < closest_dist:
+            closest_dist = dist
+            closest = buur
+
+    if closest:
+        return (
+            f"Buurpand ({closest['hoogte']:.0f}m, {closest_dist:.0f}m afstand) "
+            f"veroorzaakt {uren['zomer']:.0f}u schaduw in zomer"
+        )
+    return f"Buurtgebouwen veroorzaken {uren['zomer']:.0f}u schaduw in zomer"
+
+
+def _beschrijf_bomen_schaduw(
+    bomen: List[Dict[str, Any]],
+    uren: Dict[str, float],
+    tuin_x: float,
+    tuin_y: float,
+) -> Optional[str]:
+    if uren["zomer"] < 0.5 or not bomen:
+        return None
+
+    # Tel bomen die dichtbij de tuin staan
+    nabije_bomen = [
+        b for b in bomen
+        if math.hypot(b["rd_x"] - tuin_x, b["rd_y"] - tuin_y) < 30
+    ]
+    if not nabije_bomen:
+        return None
+
+    max_h = max(b["hoogte"] for b in nabije_bomen)
+    return (
+        f"{len(nabije_bomen)} {'boom' if len(nabije_bomen) == 1 else 'bomen'} "
+        f"(tot {max_h:.0f}m) {'veroorzaakt' if len(nabije_bomen) == 1 else 'veroorzaken'} "
+        f"{uren['zomer']:.0f}u schaduw in zomer"
+    )
+
+
+# --- Zonnepanelen score ---
+
+def bereken_zonnepanelen_score(
+    dak_azimut: Optional[float],
+    dak_hellingshoek: Optional[float],
+    opp_dak_schuin: Optional[float],
+    opp_dak_plat: Optional[float],
+    dak_type: Optional[str],
+) -> Dict[str, Any]:
+    """Bereken zonnepanelen geschiktheid score (1-10).
+
+    Ideaal: zuid-georiënteerd (180°), 30-40° helling.
+    """
+    if dak_azimut is None and opp_dak_plat is None and opp_dak_schuin is None:
+        return {}
+
+    score = 5.0  # Basiscore
+
+    # Oriëntatiefactor (max 3 punten)
+    if dak_azimut is not None:
+        # cos(azimut - 180) = 1 bij zuid, -1 bij noord
+        orientatie_factor = (1 + math.cos(math.radians(dak_azimut - 180))) / 2
+        score += orientatie_factor * 3.0 - 1.5
+    else:
+        # Plat dak zonder oriëntatie: panelen kunnen optimaal gericht worden
+        score += 1.0
+
+    # Hellingsfactor (max 2 punten)
+    if dak_hellingshoek is not None and dak_hellingshoek > 2:
+        # Optimaal: 30-40°
+        if 25 <= dak_hellingshoek <= 45:
+            score += 2.0
+        elif 15 <= dak_hellingshoek <= 50:
+            score += 1.0
+        else:
+            score += 0.0
+    elif dak_type and "horizontal" in dak_type.lower():
+        # Plat dak: goed, panelen op frame
+        score += 1.5
+
+    # Beschikbaar oppervlak (max 1 punt)
+    totaal_opp = (opp_dak_schuin or 0) + (opp_dak_plat or 0)
+    if totaal_opp > 40:
+        score += 1.0
+    elif totaal_opp > 20:
+        score += 0.5
+
+    score = max(1, min(10, round(score)))
+
+    # Label
+    if score >= 8:
+        label = "Zeer geschikt"
+    elif score >= 6:
+        label = "Geschikt"
+    elif score >= 4:
+        label = "Matig geschikt"
+    else:
+        label = "Beperkt geschikt"
+
+    # Bepaal geschikt oppervlak
+    geschikt_opp = None
+    if dak_type and "horizontal" in dak_type.lower():
+        # Plat dak: ~60% bruikbaar (randen, doorvoeren)
+        geschikt_opp = round((opp_dak_plat or 0) * 0.6, 1)
+    elif opp_dak_schuin and opp_dak_schuin > 0:
+        # Schuin dak: ~ 80% bruikbaar van de zuidkant
+        geschikt_opp = round(opp_dak_schuin * 0.8, 1)
+
+    dak_orient = azimut_naar_kompas(dak_azimut) if dak_azimut is not None else None
+
+    return {
+        "zonnepanelen_score": score,
+        "zonnepanelen_label": label,
+        "dak_orientatie": dak_orient,
+        "dak_hellingshoek": dak_hellingshoek,
+        "geschikt_dakoppervlak": geschikt_opp,
+    }
+
+
+# --- Hoofd-entrypoint ---
+
+def bereken_orientatie(
+    building_footprint_rd: Optional[List[List[float]]] = None,
+    perceel_polygon_rd: Optional[List[List[float]]] = None,
+    gebouwhoogte: Optional[float] = None,
+    dak_azimut: Optional[float] = None,
+    dak_hellingshoek: Optional[float] = None,
+    opp_dak_schuin: Optional[float] = None,
+    opp_dak_plat: Optional[float] = None,
+    dak_type: Optional[str] = None,
+    buurtgebouwen: Optional[List[Dict[str, Any]]] = None,
+    bomen: Optional[List[Dict[str, Any]]] = None,
+    funda_tuin_orientatie: Optional[str] = None,
+    latitude: float = 52.0,
+) -> OrientatieResult:
+    """Hoofd-entrypoint voor oriëntatie- en zonanalyse."""
+    result = OrientatieResult()
+    methode_parts = []
+
+    # 1. Tuinoriëntatie
+    tuin_label, tuin_az, tuin_opp = bepaal_tuin_orientatie(
+        building_footprint_rd, perceel_polygon_rd, funda_tuin_orientatie
+    )
+    result.tuin_orientatie = tuin_label
+    result.tuin_azimut = tuin_az
+    result.tuin_oppervlakte_berekend = tuin_opp
+
+    if building_footprint_rd and perceel_polygon_rd:
+        methode_parts.append("3DBAG+Kadaster")
+    elif funda_tuin_orientatie:
+        methode_parts.append("Funda")
+
+    # 2. Zonuren met schaduwanalyse
+    if tuin_az is not None and building_footprint_rd:
+        try:
+            from shapely.geometry import Polygon
+
+            # Bereken tuin-centroid
+            building = Polygon(building_footprint_rd)
+            if perceel_polygon_rd:
+                perceel = Polygon(perceel_polygon_rd)
+                tuin = perceel.difference(building.buffer(0))
+                if hasattr(tuin, 'geoms'):
+                    tuin_main = max(tuin.geoms, key=lambda p: p.area)
+                else:
+                    tuin_main = tuin
+                tuin_cx, tuin_cy = tuin_main.centroid.x, tuin_main.centroid.y
+            else:
+                # Schat tuin-centroid op basis van azimut
+                bld_cx, bld_cy = building.centroid.x, building.centroid.y
+                offset = 10.0  # 10m achter het huis
+                tuin_cx = bld_cx + offset * math.sin(math.radians(tuin_az))
+                tuin_cy = bld_cy + offset * math.cos(math.radians(tuin_az))
+
+            zon_data = bereken_zon_uren(
+                tuin_cx, tuin_cy,
+                building_footprint_rd,
+                gebouwhoogte or 0,
+                buurtgebouwen or [],
+                bomen or [],
+                latitude,
+            )
+
+            result.zon_uren_zomer = zon_data.get("zon_uren_zomer")
+            result.zon_uren_lente = zon_data.get("zon_uren_lente")
+            result.zon_uren_winter = zon_data.get("zon_uren_winter")
+            result.zon_label = zon_data.get("zon_label")
+            result.schaduw_eigen_gebouw = zon_data.get("schaduw_eigen_gebouw")
+            result.schaduw_buren = zon_data.get("schaduw_buren")
+            result.schaduw_bomen = zon_data.get("schaduw_bomen")
+            result.effectieve_tuin_diepte = zon_data.get("effectieve_tuin_diepte")
+
+            if buurtgebouwen or bomen:
+                methode_parts.append("AHN+BGT")
+
+        except Exception as e:
+            logger.warning(f"Fout bij zonurenberekening: {e}")
+
+    # 3. Zonnepanelen score
+    paneel_data = bereken_zonnepanelen_score(
+        dak_azimut, dak_hellingshoek, opp_dak_schuin, opp_dak_plat, dak_type
+    )
+    if paneel_data:
+        result.zonnepanelen_score = paneel_data.get("zonnepanelen_score")
+        result.zonnepanelen_label = paneel_data.get("zonnepanelen_label")
+        result.dak_orientatie = paneel_data.get("dak_orientatie")
+        result.dak_hellingshoek = paneel_data.get("dak_hellingshoek")
+        result.geschikt_dakoppervlak = paneel_data.get("geschikt_dakoppervlak")
+
+    # Meta
+    result.methode = "+".join(methode_parts) if methode_parts else None
+    if building_footprint_rd and perceel_polygon_rd and (buurtgebouwen or bomen):
+        result.betrouwbaarheid = "hoog"
+    elif building_footprint_rd or funda_tuin_orientatie:
+        result.betrouwbaarheid = "gemiddeld"
+    else:
+        result.betrouwbaarheid = "laag"
+
+    details = []
+    if result.tuin_orientatie:
+        details.append(f"Tuin op het {result.tuin_orientatie.lower()}")
+    if result.zon_uren_zomer is not None:
+        details.append(f"{result.zon_uren_zomer:.0f}u zon in zomer")
+    if result.effectieve_tuin_diepte:
+        details.append(f"Eigen schaduw tot {result.effectieve_tuin_diepte:.0f}m")
+    result.details = ", ".join(details) if details else None
+
+    return result

--- a/backend/services/orientatie.py
+++ b/backend/services/orientatie.py
@@ -46,6 +46,10 @@ class OrientatieResult:
     dak_hellingshoek: Optional[float] = None
     geschikt_dakoppervlak: Optional[float] = None
 
+    # Funda vergelijking
+    funda_tuin_orientatie: Optional[str] = None
+    funda_tuin_oppervlakte: Optional[int] = None
+
     # Meta
     methode: Optional[str] = None
     betrouwbaarheid: Optional[str] = None
@@ -130,20 +134,268 @@ def azimut_naar_kompas(azimut: float) -> str:
     return best_label
 
 
+# --- Voorkant-detectie (V5-algoritme) ---
+
+def bepaal_voorkant_richting(
+    rd_x: float,
+    rd_y: float,
+    road_polygons: List[Dict[str, Any]],
+) -> tuple[Optional[str], Optional[float], str]:
+    """Bepaal de voorkant-richting van een woning via BGT wegdelen.
+
+    Gebruikt het V5-algoritme: combineert voetpad, rijbaan en inrit
+    signalen. Gevalideerd op 99 adressen: 76% exact, 84% ≤45° afwijking.
+
+    Parameters
+    ----------
+    rd_x, rd_y : float
+        Adrespunt in RD-coördinaten
+    road_polygons : list of dict
+        BGT wegdelen met 'polygon_coords' en 'functie'
+
+    Returns
+    -------
+    tuple of (richting_label, azimut, methode)
+        richting = kompasrichting van de VOORKANT (straat-zijde)
+        azimut = graden (0=N, 90=O, etc.)
+        methode = welk signaal gebruikt is
+    """
+    try:
+        from shapely.geometry import Point, Polygon
+        from shapely.ops import nearest_points
+    except ImportError:
+        return None, None, "geen_shapely"
+
+    addr_point = Point(rd_x, rd_y)
+
+    def _nearest_in_types(types, max_dist):
+        """Vind dichtstbijzijnde wegdeel van gegeven types."""
+        best_dist = float("inf")
+        best_point = None
+        for road in road_polygons:
+            if road.get("functie") not in types:
+                continue
+            coords = road.get("polygon_coords")
+            if not coords or len(coords) < 3:
+                continue
+            try:
+                poly = Polygon(coords)
+                if not poly.is_valid:
+                    poly = poly.buffer(0)
+                p1, p2 = nearest_points(addr_point, poly)
+                dist = p1.distance(p2)
+                if dist < best_dist and dist < max_dist:
+                    best_dist = dist
+                    best_point = p2
+            except Exception:
+                continue
+        if best_point is None:
+            return None, None
+        dx = best_point.x - rd_x
+        dy = best_point.y - rd_y
+        front_az = math.degrees(math.atan2(dx, dy)) % 360
+        return front_az, best_dist
+
+    def _angle_diff(a1, a2):
+        d = abs(a1 - a2) % 360
+        return min(d, 360 - d)
+
+    # Zoek dichtstbijzijnde per type
+    inrit_az, inrit_dist = _nearest_in_types({"inrit"}, 15)
+    voetpad_az, voetpad_dist = _nearest_in_types({"voetpad"}, 20)
+    rijbaan_az, rijbaan_dist = _nearest_in_types(
+        {"rijbaan lokale weg", "rijbaan regionale weg", "woonerf"}, 50
+    )
+
+    # Beslissingslogica
+    front_az = None
+    methode = "geen_wegen"
+
+    if inrit_az is not None:
+        front_az = inrit_az
+        methode = "inrit"
+    elif voetpad_az is not None and rijbaan_az is not None:
+        diff = _angle_diff(voetpad_az, rijbaan_az)
+        if diff <= 45:
+            # Voetpad en rijbaan eens → gebruik rijbaan (nauwkeuriger)
+            front_az = rijbaan_az
+            methode = "voetpad+rijbaan"
+        elif (voetpad_dist is not None and voetpad_dist < 15
+              and (rijbaan_dist is None or voetpad_dist < rijbaan_dist)):
+            # Oneens, voetpad dichterbij dan rijbaan → vertrouw voetpad
+            front_az = voetpad_az
+            methode = "voetpad"
+        else:
+            # Oneens, rijbaan dichterbij of voetpad ver → vertrouw rijbaan
+            front_az = rijbaan_az
+            methode = "rijbaan"
+    elif voetpad_az is not None:
+        front_az = voetpad_az
+        methode = "voetpad"
+    elif rijbaan_az is not None:
+        front_az = rijbaan_az
+        methode = "rijbaan"
+
+    if front_az is None:
+        return None, None, methode
+
+    label = azimut_naar_kompas(front_az)
+    return label, round(front_az, 1), methode
+
+
 # --- Tuinoriëntatie ---
 
 def bepaal_tuin_orientatie(
+    rd_x: float,
+    rd_y: float,
     building_footprint_rd: Optional[List[List[float]]],
     perceel_polygon_rd: Optional[List[List[float]]],
+    road_polygons: Optional[List[Dict[str, Any]]] = None,
     funda_tuin_orientatie: Optional[str] = None,
-) -> tuple[Optional[str], Optional[float], Optional[float]]:
-    """Bepaal tuinoriëntatie op basis van perceelgrens en gebouw-footprint.
+) -> tuple[Optional[str], Optional[float], Optional[float], str]:
+    """Bepaal tuinoriëntatie via BGT wegdelen (V5-algoritme).
 
-    Returns (orientatie_label, azimut, tuin_oppervlakte)
+    Stap 1: Bepaal voorkant via BGT (straat/voetpad/inrit)
+    Stap 2: Tuin = tegenovergestelde richting
+    Stap 3: Splits open ruimte in voor/achter voor oppervlakte
+
+    Returns (orientatie_label, azimut, tuin_oppervlakte, betrouwbaarheid)
+    """
+    betrouwbaarheid = "laag"
+
+    # Stap 1: Voorkant bepalen via BGT wegdelen
+    front_label = None
+    front_az = None
+    front_methode = "geen_wegen"
+
+    if road_polygons:
+        front_label, front_az, front_methode = bepaal_voorkant_richting(
+            rd_x, rd_y, road_polygons
+        )
+
+    # Stap 2: Tuin = tegenover voorkant
+    tuin_az = None
+    tuin_label = None
+
+    if front_az is not None:
+        tuin_az = (front_az + 180) % 360
+        tuin_label = azimut_naar_kompas(tuin_az)
+
+        if front_methode == "voetpad+rijbaan":
+            betrouwbaarheid = "hoog"
+        elif front_methode in ("voetpad", "rijbaan", "inrit"):
+            betrouwbaarheid = "middel"
+
+    # Stap 3: Tuinoppervlakte berekenen (splits perceel in voor/achter)
+    tuin_opp = None
+    if building_footprint_rd and perceel_polygon_rd and tuin_az is not None:
+        tuin_opp = _bereken_tuin_oppervlakte(
+            building_footprint_rd, perceel_polygon_rd, tuin_az
+        )
+
+    # Fallback: Funda oriëntatie als BGT geen resultaat geeft
+    if tuin_label is None and funda_tuin_orientatie:
+        parsed_label, parsed_az, _ = _parse_funda_orientatie(funda_tuin_orientatie)
+        if parsed_label:
+            tuin_label = parsed_label
+            tuin_az = parsed_az
+            betrouwbaarheid = "laag"
+
+    return tuin_label, tuin_az, tuin_opp, betrouwbaarheid
+
+
+def _bereken_tuin_oppervlakte(
+    building_footprint_rd: List[List[float]],
+    perceel_polygon_rd: List[List[float]],
+    tuin_azimut: float,
+) -> Optional[float]:
+    """Bereken tuinoppervlakte door perceel te splitsen in voor/achter.
+
+    Splitst de open ruimte (perceel - gebouw) met een lijn loodrecht
+    op de voor-achter-as door het gebouw-centroid. De helft in de
+    tuin-richting = tuinoppervlakte.
+    """
+    try:
+        from shapely.geometry import LineString, MultiPolygon, Polygon
+        from shapely.ops import split
+
+        building = Polygon(building_footprint_rd)
+        perceel = Polygon(perceel_polygon_rd)
+
+        if not building.is_valid:
+            building = building.buffer(0)
+        if not perceel.is_valid:
+            perceel = perceel.buffer(0)
+
+        open_ruimte = perceel.difference(building)
+        if open_ruimte.is_empty or open_ruimte.area < 1.0:
+            return 0.0
+
+        # Splitlijn: loodrecht op de voor-achter-as door building centroid
+        bld_cx, bld_cy = building.centroid.x, building.centroid.y
+
+        # Richting loodrecht op tuin-azimut (= loodrecht op voor-achter-as)
+        perp_az = math.radians((tuin_azimut + 90) % 360)
+        line_len = 100.0  # Ruim genoeg om perceel te doorkruisen
+        x1 = bld_cx + math.sin(perp_az) * line_len
+        y1 = bld_cy + math.cos(perp_az) * line_len
+        x2 = bld_cx - math.sin(perp_az) * line_len
+        y2 = bld_cy - math.cos(perp_az) * line_len
+
+        split_line = LineString([(x1, y1), (x2, y2)])
+
+        # Split de open ruimte
+        try:
+            parts = split(open_ruimte, split_line)
+        except Exception:
+            # Als split faalt, geef totale open ruimte
+            return round(open_ruimte.area, 1)
+
+        if len(parts.geoms) < 2:
+            return round(open_ruimte.area, 1)
+
+        # Bepaal welke helft de tuin-kant is
+        tuin_rad = math.radians(tuin_azimut)
+        ref_x = bld_cx + math.sin(tuin_rad) * 20
+        ref_y = bld_cy + math.cos(tuin_rad) * 20
+
+        # De helft waarvan het centroid het dichtst bij het tuin-referentiepunt ligt
+        best_part = None
+        best_dist = float("inf")
+        for part in parts.geoms:
+            if part.is_empty:
+                continue
+            cx, cy = part.centroid.x, part.centroid.y
+            dist = math.hypot(cx - ref_x, cy - ref_y)
+            if dist < best_dist:
+                best_dist = dist
+                best_part = part
+
+        if best_part:
+            return round(best_part.area, 1)
+        return round(open_ruimte.area, 1)
+
+    except Exception as e:
+        logger.warning(f"Fout bij tuinoppervlakte berekening: {e}")
+        return None
+
+
+def bereken_tuin_centroid(
+    rd_x: float,
+    rd_y: float,
+    tuin_azimut: float,
+    building_footprint_rd: Optional[List[List[float]]],
+    perceel_polygon_rd: Optional[List[List[float]]],
+) -> tuple[float, float]:
+    """Bereken het meetpunt voor schaduwanalyse in de tuin.
+
+    Als tuinpolygoon beschikbaar: gebruik centroid van achterhelft.
+    Anders: 8m van gebouw-rand in tuin-richting.
     """
     if building_footprint_rd and perceel_polygon_rd:
         try:
-            from shapely.geometry import MultiPolygon, Polygon
+            from shapely.geometry import LineString, Polygon
+            from shapely.ops import split
 
             building = Polygon(building_footprint_rd)
             perceel = Polygon(perceel_polygon_rd)
@@ -153,43 +405,45 @@ def bepaal_tuin_orientatie(
             if not perceel.is_valid:
                 perceel = perceel.buffer(0)
 
-            tuin = perceel.difference(building)
-            tuin_opp = round(tuin.area, 1)
+            open_ruimte = perceel.difference(building)
+            if not open_ruimte.is_empty and open_ruimte.area > 1.0:
+                # Split en gebruik tuin-helft centroid
+                bld_cx, bld_cy = building.centroid.x, building.centroid.y
+                perp_az = math.radians((tuin_azimut + 90) % 360)
+                line_len = 100.0
+                split_line = LineString([
+                    (bld_cx + math.sin(perp_az) * line_len,
+                     bld_cy + math.cos(perp_az) * line_len),
+                    (bld_cx - math.sin(perp_az) * line_len,
+                     bld_cy - math.cos(perp_az) * line_len),
+                ])
 
-            if tuin_opp < 1.0:
-                return None, None, 0.0
+                try:
+                    parts = split(open_ruimte, split_line)
+                    if len(parts.geoms) >= 2:
+                        tuin_rad = math.radians(tuin_azimut)
+                        ref_x = bld_cx + math.sin(tuin_rad) * 20
+                        ref_y = bld_cy + math.cos(tuin_rad) * 20
 
-            # Bepaal tuinoriëntatie: richting van gebouw-centroid naar tuin-centroid
-            bld_cx, bld_cy = building.centroid.x, building.centroid.y
-
-            # Voor MultiPolygon (L-vormige tuinen bij hoekwoningen):
-            # gebruik het grootste deel
-            if isinstance(tuin, MultiPolygon):
-                tuin_parts = list(tuin.geoms)
-                tuin_main = max(tuin_parts, key=lambda p: p.area)
-            else:
-                tuin_main = tuin
-
-            tuin_cx, tuin_cy = tuin_main.centroid.x, tuin_main.centroid.y
-
-            # Vector van gebouw naar tuin
-            dx = tuin_cx - bld_cx
-            dy = tuin_cy - bld_cy
-
-            # Azimut: 0=Noord, 90=Oost, 180=Zuid, 270=West
-            azimut = (math.degrees(math.atan2(dx, dy)) + 360) % 360
-            label = azimut_naar_kompas(azimut)
-
-            return label, round(azimut, 1), tuin_opp
+                        best_part = min(
+                            (p for p in parts.geoms if not p.is_empty),
+                            key=lambda p: math.hypot(
+                                p.centroid.x - ref_x, p.centroid.y - ref_y
+                            ),
+                        )
+                        return best_part.centroid.x, best_part.centroid.y
+                except Exception:
+                    pass
 
         except Exception as e:
-            logger.warning(f"Fout bij tuinoriëntatie berekening: {e}")
+            logger.debug(f"Tuin-centroid via perceel mislukt: {e}")
 
-    # Fallback: parse Funda tuin_orientatie
-    if funda_tuin_orientatie:
-        return _parse_funda_orientatie(funda_tuin_orientatie)
-
-    return None, None, None
+    # Fallback: 8m van adrespunt in tuin-richting
+    tuin_rad = math.radians(tuin_azimut)
+    return (
+        rd_x + math.sin(tuin_rad) * 8.0,
+        rd_y + math.cos(tuin_rad) * 8.0,
+    )
 
 
 def _parse_funda_orientatie(
@@ -560,36 +814,72 @@ def bereken_zonnepanelen_score(
     opp_dak_schuin: Optional[float],
     opp_dak_plat: Optional[float],
     dak_type: Optional[str],
+    dak_delen: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Bereken zonnepanelen geschiktheid score (1-10).
 
-    Ideaal: zuid-georiënteerd (180°), 30-40° helling.
+    Bij een zadeldak (twee schuine vlakken) wordt het best georiënteerde
+    vlak gebruikt voor de score. Ideaal: zuid-georiënteerd (180°), 30-40° helling.
     """
     if dak_azimut is None and opp_dak_plat is None and opp_dak_schuin is None:
         return {}
 
+    # Bij meerdere schuine dakdelen: kies het best georiënteerde vlak
+    beste_azimut = dak_azimut
+    beste_hellingshoek = dak_hellingshoek
+    alle_vlakken = []
+    if dak_delen:
+        schuine_delen = [
+            d for d in dak_delen
+            if d.get("hellingshoek") is not None and d["hellingshoek"] > 5
+        ]
+        if schuine_delen:
+            # Merge dakdelen met vergelijkbare azimut (binnen 15°)
+            merged = []
+            for deel in schuine_delen:
+                az = deel["azimut"]
+                found = False
+                for m in merged:
+                    diff = abs(az - m["azimut"])
+                    if diff > 180:
+                        diff = 360 - diff
+                    if diff < 15:
+                        # Merge: gewogen gemiddelde
+                        m["hellingshoek"] = (m["hellingshoek"] + deel["hellingshoek"]) / 2
+                        found = True
+                        break
+                if not found:
+                    merged.append({"azimut": az, "hellingshoek": deel["hellingshoek"]})
+
+            for m in merged:
+                az = m["azimut"]
+                orient_score = (1 + math.cos(math.radians(az - 180))) / 2
+                alle_vlakken.append({
+                    "azimut": az,
+                    "hellingshoek": m["hellingshoek"],
+                    "richting": azimut_naar_kompas(az),
+                    "orient_score": orient_score,
+                })
+            alle_vlakken.sort(key=lambda v: v["orient_score"], reverse=True)
+            beste_azimut = alle_vlakken[0]["azimut"]
+            beste_hellingshoek = alle_vlakken[0]["hellingshoek"]
+
     score = 5.0  # Basiscore
 
-    # Oriëntatiefactor (max 3 punten)
-    if dak_azimut is not None:
-        # cos(azimut - 180) = 1 bij zuid, -1 bij noord
-        orientatie_factor = (1 + math.cos(math.radians(dak_azimut - 180))) / 2
+    # Oriëntatiefactor (max 3 punten) — gebruik beste dakvlak
+    if beste_azimut is not None:
+        orientatie_factor = (1 + math.cos(math.radians(beste_azimut - 180))) / 2
         score += orientatie_factor * 3.0 - 1.5
     else:
-        # Plat dak zonder oriëntatie: panelen kunnen optimaal gericht worden
         score += 1.0
 
     # Hellingsfactor (max 2 punten)
-    if dak_hellingshoek is not None and dak_hellingshoek > 2:
-        # Optimaal: 30-40°
-        if 25 <= dak_hellingshoek <= 45:
+    if beste_hellingshoek is not None and beste_hellingshoek > 2:
+        if 25 <= beste_hellingshoek <= 45:
             score += 2.0
-        elif 15 <= dak_hellingshoek <= 50:
+        elif 15 <= beste_hellingshoek <= 50:
             score += 1.0
-        else:
-            score += 0.0
     elif dak_type and "horizontal" in dak_type.lower():
-        # Plat dak: goed, panelen op frame
         score += 1.5
 
     # Beschikbaar oppervlak (max 1 punt)
@@ -601,7 +891,6 @@ def bereken_zonnepanelen_score(
 
     score = max(1, min(10, round(score)))
 
-    # Label
     if score >= 8:
         label = "Zeer geschikt"
     elif score >= 6:
@@ -611,22 +900,31 @@ def bereken_zonnepanelen_score(
     else:
         label = "Beperkt geschikt"
 
-    # Bepaal geschikt oppervlak
+    # Geschikt oppervlak: bij zadeldak alleen het beste vlak (~50% van schuin)
     geschikt_opp = None
     if dak_type and "horizontal" in dak_type.lower():
-        # Plat dak: ~60% bruikbaar (randen, doorvoeren)
         geschikt_opp = round((opp_dak_plat or 0) * 0.6, 1)
     elif opp_dak_schuin and opp_dak_schuin > 0:
-        # Schuin dak: ~ 80% bruikbaar van de zuidkant
-        geschikt_opp = round(opp_dak_schuin * 0.8, 1)
+        if len(alle_vlakken) >= 2:
+            # Zadeldak: ~50% van schuin oppervlak is het beste vlak, 80% daarvan bruikbaar
+            geschikt_opp = round(opp_dak_schuin * 0.5 * 0.8, 1)
+        else:
+            geschikt_opp = round(opp_dak_schuin * 0.8, 1)
 
-    dak_orient = azimut_naar_kompas(dak_azimut) if dak_azimut is not None else None
+    # Toon oriëntatie van het beste vlak
+    dak_orient = azimut_naar_kompas(beste_azimut) if beste_azimut is not None else None
+
+    # Bij zadeldak: voeg info over beide vlakken toe
+    dak_orient_detail = None
+    if len(alle_vlakken) >= 2:
+        vlak_labels = [f"{v['richting']} ({v['hellingshoek']:.0f}°)" for v in alle_vlakken]
+        dak_orient_detail = " / ".join(vlak_labels)
 
     return {
         "zonnepanelen_score": score,
         "zonnepanelen_label": label,
-        "dak_orientatie": dak_orient,
-        "dak_hellingshoek": dak_hellingshoek,
+        "dak_orientatie": dak_orient_detail or dak_orient,
+        "dak_hellingshoek": round(beste_hellingshoek, 1) if beste_hellingshoek is not None else None,
         "geschikt_dakoppervlak": geschikt_opp,
     }
 
@@ -634,6 +932,8 @@ def bereken_zonnepanelen_score(
 # --- Hoofd-entrypoint ---
 
 def bereken_orientatie(
+    rd_x: float = 0.0,
+    rd_y: float = 0.0,
     building_footprint_rd: Optional[List[List[float]]] = None,
     perceel_polygon_rd: Optional[List[List[float]]] = None,
     gebouwhoogte: Optional[float] = None,
@@ -642,49 +942,63 @@ def bereken_orientatie(
     opp_dak_schuin: Optional[float] = None,
     opp_dak_plat: Optional[float] = None,
     dak_type: Optional[str] = None,
+    dak_delen: Optional[List[Dict[str, Any]]] = None,
     buurtgebouwen: Optional[List[Dict[str, Any]]] = None,
     bomen: Optional[List[Dict[str, Any]]] = None,
+    road_polygons: Optional[List[Dict[str, Any]]] = None,
     funda_tuin_orientatie: Optional[str] = None,
+    funda_tuin_oppervlakte: Optional[int] = None,
     latitude: float = 52.0,
 ) -> OrientatieResult:
-    """Hoofd-entrypoint voor oriëntatie- en zonanalyse."""
+    """Hoofd-entrypoint voor oriëntatie- en zonanalyse.
+
+    Parameters
+    ----------
+    rd_x, rd_y : float
+        Adrespunt in RD-coördinaten (voor voorkant-detectie)
+    road_polygons : list of dict, optional
+        BGT wegdelen voor voorkant-detectie (V5-algoritme)
+    funda_tuin_orientatie : str, optional
+        Funda tuinoriëntatie voor vergelijking en fallback
+    funda_tuin_oppervlakte : int, optional
+        Funda tuinoppervlakte voor vergelijking
+    """
     result = OrientatieResult()
     methode_parts = []
 
-    # 1. Tuinoriëntatie
-    tuin_label, tuin_az, tuin_opp = bepaal_tuin_orientatie(
-        building_footprint_rd, perceel_polygon_rd, funda_tuin_orientatie
+    # 1. Tuinoriëntatie via BGT wegdelen (V5-algoritme)
+    tuin_label, tuin_az, tuin_opp, betrouwbaarheid = bepaal_tuin_orientatie(
+        rd_x, rd_y,
+        building_footprint_rd, perceel_polygon_rd,
+        road_polygons=road_polygons,
+        funda_tuin_orientatie=funda_tuin_orientatie,
     )
     result.tuin_orientatie = tuin_label
     result.tuin_azimut = tuin_az
     result.tuin_oppervlakte_berekend = tuin_opp
 
+    # Funda vergelijking
+    if funda_tuin_orientatie:
+        parsed_label, _, _ = _parse_funda_orientatie(funda_tuin_orientatie)
+        result.funda_tuin_orientatie = parsed_label
+    if funda_tuin_oppervlakte:
+        result.funda_tuin_oppervlakte = funda_tuin_oppervlakte
+
+    if road_polygons:
+        methode_parts.append("BGT")
     if building_footprint_rd and perceel_polygon_rd:
-        methode_parts.append("3DBAG+Kadaster")
-    elif funda_tuin_orientatie:
+        methode_parts.append("Kadaster")
+    elif funda_tuin_orientatie and not road_polygons:
         methode_parts.append("Funda")
 
     # 2. Zonuren met schaduwanalyse
     if tuin_az is not None and building_footprint_rd:
         try:
-            from shapely.geometry import Polygon
-
-            # Bereken tuin-centroid
-            building = Polygon(building_footprint_rd)
-            if perceel_polygon_rd:
-                perceel = Polygon(perceel_polygon_rd)
-                tuin = perceel.difference(building.buffer(0))
-                if hasattr(tuin, 'geoms'):
-                    tuin_main = max(tuin.geoms, key=lambda p: p.area)
-                else:
-                    tuin_main = tuin
-                tuin_cx, tuin_cy = tuin_main.centroid.x, tuin_main.centroid.y
-            else:
-                # Schat tuin-centroid op basis van azimut
-                bld_cx, bld_cy = building.centroid.x, building.centroid.y
-                offset = 10.0  # 10m achter het huis
-                tuin_cx = bld_cx + offset * math.sin(math.radians(tuin_az))
-                tuin_cy = bld_cy + offset * math.cos(math.radians(tuin_az))
+            # Bereken tuin-centroid via de nieuwe methode
+            tuin_cx, tuin_cy = bereken_tuin_centroid(
+                rd_x, rd_y, tuin_az,
+                building_footprint_rd, perceel_polygon_rd,
+            )
 
             zon_data = bereken_zon_uren(
                 tuin_cx, tuin_cy,
@@ -705,14 +1019,15 @@ def bereken_orientatie(
             result.effectieve_tuin_diepte = zon_data.get("effectieve_tuin_diepte")
 
             if buurtgebouwen or bomen:
-                methode_parts.append("AHN+BGT")
+                methode_parts.append("AHN+BGT_bomen")
 
         except Exception as e:
             logger.warning(f"Fout bij zonurenberekening: {e}")
 
     # 3. Zonnepanelen score
     paneel_data = bereken_zonnepanelen_score(
-        dak_azimut, dak_hellingshoek, opp_dak_schuin, opp_dak_plat, dak_type
+        dak_azimut, dak_hellingshoek, opp_dak_schuin, opp_dak_plat, dak_type,
+        dak_delen=dak_delen,
     )
     if paneel_data:
         result.zonnepanelen_score = paneel_data.get("zonnepanelen_score")
@@ -723,12 +1038,7 @@ def bereken_orientatie(
 
     # Meta
     result.methode = "+".join(methode_parts) if methode_parts else None
-    if building_footprint_rd and perceel_polygon_rd and (buurtgebouwen or bomen):
-        result.betrouwbaarheid = "hoog"
-    elif building_footprint_rd or funda_tuin_orientatie:
-        result.betrouwbaarheid = "gemiddeld"
-    else:
-        result.betrouwbaarheid = "laag"
+    result.betrouwbaarheid = betrouwbaarheid
 
     details = []
     if result.tuin_orientatie:

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -380,12 +380,39 @@ function OrientatiePanel({ orientatie }: { orientatie: OrientatieResponse }) {
         <div className="mb-3">
           <div className="flex justify-between text-sm">
             <span className="text-yellow-600">Tuin</span>
-            <span className="text-yellow-800 font-medium">{orientatie.tuin_orientatie}</span>
+            <span className="text-yellow-800 font-medium">
+              {orientatie.tuin_orientatie}
+              {orientatie.funda_tuin_orientatie && (
+                <span className="ml-2 text-xs font-normal">
+                  {orientatie.tuin_orientatie === orientatie.funda_tuin_orientatie ? (
+                    <span className="text-green-600">· Funda: {orientatie.funda_tuin_orientatie} ✓</span>
+                  ) : (
+                    <span className="text-orange-500">· Funda: {orientatie.funda_tuin_orientatie}</span>
+                  )}
+                </span>
+              )}
+            </span>
           </div>
           {orientatie.tuin_oppervlakte_berekend != null && orientatie.tuin_oppervlakte_berekend > 0 && (
             <div className="flex justify-between text-sm">
-              <span className="text-yellow-600">Tuinoppervlakte (berekend)</span>
-              <span className="text-yellow-800">{Math.round(orientatie.tuin_oppervlakte_berekend)} m²</span>
+              <span className="text-yellow-600">Tuinoppervlakte</span>
+              <span className="text-yellow-800">
+                {Math.round(orientatie.tuin_oppervlakte_berekend)} m²
+                {orientatie.funda_tuin_oppervlakte != null && (
+                  <span className="ml-1 text-xs text-yellow-500">(Funda: {orientatie.funda_tuin_oppervlakte} m²)</span>
+                )}
+              </span>
+            </div>
+          )}
+          {orientatie.betrouwbaarheid && (
+            <div className="text-xs mt-0.5">
+              <span className={
+                orientatie.betrouwbaarheid === 'hoog' ? 'text-green-600' :
+                orientatie.betrouwbaarheid === 'middel' ? 'text-yellow-600' :
+                'text-orange-500'
+              }>
+                Betrouwbaarheid: {orientatie.betrouwbaarheid}
+              </span>
             </div>
           )}
         </div>

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -9,6 +9,7 @@ import {
   FundaListing,
   PlafondhoogteResponse,
   GlasvezelResponse,
+  OrientatieResponse,
   formatPrijs,
   formatM2Prijs,
 } from '../services/api'
@@ -356,6 +357,123 @@ function GlasvezelPanel({ glasvezel }: { glasvezel: GlasvezelResponse }) {
   )
 }
 
+function OrientatiePanel({ orientatie }: { orientatie: OrientatieResponse }) {
+  const scoreKleur = (score: number) => {
+    if (score >= 8) return 'text-green-700 bg-green-100'
+    if (score >= 6) return 'text-yellow-700 bg-yellow-100'
+    if (score >= 4) return 'text-orange-700 bg-orange-100'
+    return 'text-red-700 bg-red-100'
+  }
+
+  const zonLabelKleur = (label: string) => {
+    if (label === 'Veel zon') return 'text-yellow-700'
+    if (label === 'Gemiddeld') return 'text-orange-600'
+    return 'text-gray-600'
+  }
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+      <div className="text-sm text-yellow-700 font-medium mb-3">Zon & Oriëntatie</div>
+
+      {/* Tuinoriëntatie */}
+      {orientatie.tuin_orientatie && (
+        <div className="mb-3">
+          <div className="flex justify-between text-sm">
+            <span className="text-yellow-600">Tuin</span>
+            <span className="text-yellow-800 font-medium">{orientatie.tuin_orientatie}</span>
+          </div>
+          {orientatie.tuin_oppervlakte_berekend != null && orientatie.tuin_oppervlakte_berekend > 0 && (
+            <div className="flex justify-between text-sm">
+              <span className="text-yellow-600">Tuinoppervlakte (berekend)</span>
+              <span className="text-yellow-800">{Math.round(orientatie.tuin_oppervlakte_berekend)} m²</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Zonuren */}
+      {orientatie.zon_uren_zomer != null && (
+        <div className="mb-3">
+          <div className="flex items-center justify-between text-sm mb-1">
+            <span className="text-yellow-600">Zonuren tuin</span>
+            {orientatie.zon_label && (
+              <span className={`text-xs font-medium ${zonLabelKleur(orientatie.zon_label)}`}>
+                {orientatie.zon_label}
+              </span>
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="text-center">
+              <div className="text-xs text-yellow-500">Zomer</div>
+              <div className="text-sm font-semibold text-yellow-800">{orientatie.zon_uren_zomer}u</div>
+            </div>
+            {orientatie.zon_uren_lente != null && (
+              <div className="text-center">
+                <div className="text-xs text-yellow-500">Lente/Herfst</div>
+                <div className="text-sm font-semibold text-yellow-800">{orientatie.zon_uren_lente}u</div>
+              </div>
+            )}
+            {orientatie.zon_uren_winter != null && (
+              <div className="text-center">
+                <div className="text-xs text-yellow-500">Winter</div>
+                <div className="text-sm font-semibold text-yellow-800">{orientatie.zon_uren_winter}u</div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Schaduw info */}
+      {(orientatie.schaduw_eigen_gebouw || orientatie.schaduw_buren || orientatie.schaduw_bomen) && (
+        <div className="mb-3 space-y-1">
+          {orientatie.schaduw_eigen_gebouw && (
+            <div className="text-xs text-yellow-600">{orientatie.schaduw_eigen_gebouw}</div>
+          )}
+          {orientatie.schaduw_buren && (
+            <div className="text-xs text-yellow-600">{orientatie.schaduw_buren}</div>
+          )}
+          {orientatie.schaduw_bomen && (
+            <div className="text-xs text-yellow-600">{orientatie.schaduw_bomen}</div>
+          )}
+        </div>
+      )}
+
+      {/* Zonnepanelen */}
+      {orientatie.zonnepanelen_score != null && (
+        <div className="border-t border-yellow-200 pt-2 mt-2">
+          <div className="flex items-center justify-between text-sm mb-1">
+            <span className="text-yellow-600">Zonnepanelen</span>
+            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${scoreKleur(orientatie.zonnepanelen_score)}`}>
+              {orientatie.zonnepanelen_score}/10 {orientatie.zonnepanelen_label}
+            </span>
+          </div>
+          <div className="space-y-0.5">
+            {orientatie.dak_orientatie && (
+              <div className="flex justify-between text-xs">
+                <span className="text-yellow-500">Dak</span>
+                <span className="text-yellow-700">{orientatie.dak_orientatie}{orientatie.dak_hellingshoek != null && `, ${orientatie.dak_hellingshoek}°`}</span>
+              </div>
+            )}
+            {orientatie.geschikt_dakoppervlak != null && orientatie.geschikt_dakoppervlak > 0 && (
+              <div className="flex justify-between text-xs">
+                <span className="text-yellow-500">Geschikt oppervlak</span>
+                <span className="text-yellow-700">{Math.round(orientatie.geschikt_dakoppervlak)} m²</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Disclaimer */}
+      {orientatie.methode && (
+        <div className="text-xs text-yellow-400 mt-2">
+          Indicatief ({orientatie.methode})
+        </div>
+      )}
+    </div>
+  )
+}
+
 function FundaListingPanel({ listing, bagWoonoppervlakte, plafondhoogte }: { listing: FundaListing, bagWoonoppervlakte?: number, plafondhoogte?: PlafondhoogteResponse }) {
   const detailRow = (label: string, value: string | number | boolean | undefined | null) => {
     if (value === undefined || value === null) return null
@@ -618,6 +736,11 @@ function AnalyseColumn({ result, onCopy, copied }: {
       {/* Glasvezel beschikbaarheid */}
       {result.glasvezel && (
         <GlasvezelPanel glasvezel={result.glasvezel} />
+      )}
+
+      {/* Zon en oriëntatie */}
+      {result.orientatie && (
+        <OrientatiePanel orientatie={result.orientatie} />
       )}
 
       {/* Marktindicatoren */}

--- a/frontend/src/pages/WaardebepalingPage.tsx
+++ b/frontend/src/pages/WaardebepalingPage.tsx
@@ -398,8 +398,11 @@ function OrientatiePanel({ orientatie }: { orientatie: OrientatieResponse }) {
               <span className="text-yellow-600">Tuinoppervlakte</span>
               <span className="text-yellow-800">
                 {Math.round(orientatie.tuin_oppervlakte_berekend)} m²
-                {orientatie.funda_tuin_oppervlakte != null && (
-                  <span className="ml-1 text-xs text-yellow-500">(Funda: {orientatie.funda_tuin_oppervlakte} m²)</span>
+                {orientatie.tuin_oppervlakte_bron === 'schatting' && (
+                  <span className="ml-1 text-xs text-yellow-400 italic">(inschatting)</span>
+                )}
+                {orientatie.tuin_oppervlakte_bron === 'funda' && orientatie.funda_tuin_orientatie && (
+                  <span className="ml-1 text-xs text-green-500">(Funda)</span>
                 )}
               </span>
             </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -200,6 +200,8 @@ export interface EnhancedWaardebepalingResponse {
   plafondhoogte?: PlafondhoogteResponse
   // Glasvezel beschikbaarheid
   glasvezel?: GlasvezelResponse
+  // Zon en oriëntatie
+  orientatie?: OrientatieResponse
   // Data sources
   data_bronnen: string[]
 }
@@ -259,6 +261,29 @@ export interface GlasvezelResponse {
   dsl_snelheid?: number  // Mbit/s
   max_snelheid?: number  // Mbit/s
   adres_gevonden: boolean
+}
+
+// Zon en oriëntatie
+export interface OrientatieResponse {
+  tuin_orientatie?: string
+  tuin_azimut?: number
+  tuin_oppervlakte_berekend?: number
+  zon_uren_zomer?: number
+  zon_uren_lente?: number
+  zon_uren_winter?: number
+  zon_label?: string
+  schaduw_eigen_gebouw?: string
+  schaduw_buren?: string
+  schaduw_bomen?: string
+  effectieve_tuin_diepte?: number
+  zonnepanelen_score?: number
+  zonnepanelen_label?: string
+  dak_orientatie?: string
+  dak_hellingshoek?: number
+  geschikt_dakoppervlak?: number
+  methode?: string
+  betrouwbaarheid?: string
+  details?: string
 }
 
 // GeoJSON types

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -283,6 +283,7 @@ export interface OrientatieResponse {
   geschikt_dakoppervlak?: number
   funda_tuin_orientatie?: string
   funda_tuin_oppervlakte?: number
+  tuin_oppervlakte_bron?: string
   methode?: string
   betrouwbaarheid?: string
   details?: string

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -281,6 +281,8 @@ export interface OrientatieResponse {
   dak_orientatie?: string
   dak_hellingshoek?: number
   geschikt_dakoppervlak?: number
+  funda_tuin_orientatie?: string
+  funda_tuin_oppervlakte?: number
   methode?: string
   betrouwbaarheid?: string
   details?: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ python-dotenv>=1.0.0
 # Geo
 pyproj>=3.6.0
 shapely>=2.0.0
+rasterio>=1.3.0
 
 # Dev dependencies
 pytest>=7.4.0


### PR DESCRIPTION
## Summary

Closes #6

- Zon & oriëntatie analyse: tuinoriëntatie, zonuren met schaduwberekening, en zonnepanelen score
- **Tuinoriëntatie via BGT wegdelen** (V5-algoritme): voetpad + rijbaan + inrit signalen bepalen voorkant → tuin = tegenovergestelde richting. Gevalideerd op 99 adressen: **78% exact, 86% ≤45° afwijking**
- **Hybride tuinoppervlakte**: Funda als primaire bron, eigen schatting (proportioneel) als fallback bij kleine percelen, "onbekend" bij grote percelen (VvE/appartementen)
- **Schaduwberekening**: eigen gebouw, buurtgebouwen (3DBAG), en bomen (BGT + AHN) per seizoen
- **Zonnepanelen score**: dakoriëntatie, hellingshoek, beschikbaar dakoppervlak via 3DBAG dak_delen
- Nieuwe collectors: `bgt_wegdeel_collector`, `bgt_boom_collector`, `perceelgrens_collector`
- 3DBAG spatial fallback via `get_building_by_location()` voor betere dekking
- Funda vergelijking: tuinoriëntatie en -oppervlakte naast berekende waarden

## Test plan

- [ ] Bromelia 16 (2631VK): verwacht ZO-tuin, ~37m² (Funda), realistische zonuren
- [ ] Hooikamp 62 (2264JV): verwacht NW/NO-tuin, realistische zonuren
- [ ] Adres zonder Funda-data: toont schatting met "(inschatting)" label
- [ ] Appartement (groot perceel): toont "onbekend" voor tuinoppervlakte
- [ ] Zonnepanelen score onafhankelijk van tuinoriëntatie
- [ ] TypeScript compileert zonder fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)