### PR TITLE
ORS multimodale afstanden: lopen, fietsen, auto

### DIFF
--- a/backend/api/scholen.py
+++ b/backend/api/scholen.py
@@ -1,5 +1,6 @@
 """School API routes."""
 
+import logging
 import math
 from typing import List, Optional
 
@@ -7,8 +8,21 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from collectors import create_ors_matrix_collector
 from models import get_db
 from models.school import School
+
+logger = logging.getLogger(__name__)
+
+# Singleton ORS collector (lazy init)
+_ors_collector = None
+
+
+def _get_ors_collector():
+    global _ors_collector
+    if _ors_collector is None:
+        _ors_collector = create_ors_matrix_collector()
+    return _ors_collector
 
 router = APIRouter(prefix="/api/scholen", tags=["scholen"])
 
@@ -48,6 +62,8 @@ class SchoolDetail(SchoolSummary):
 
 class SchoolNabij(SchoolSummary):
     afstand_m: float  # Afstand in meters
+    reistijd_min: int = 0
+    modaliteit: str = "lopen"
 
 
 # ── Haversine ──
@@ -112,14 +128,38 @@ def scholen_nabij(
 
     schools = query.all()
 
-    # Exact afstand berekenen en filteren
-    results = []
+    # Exact afstand berekenen en filteren (haversine pre-filter)
+    candidates = []
     for s in schools:
         afstand = _haversine(lat, lng, s.lat, s.lng)
         if afstand <= radius:
-            school_dict = SchoolSummary.model_validate(s).model_dump()
-            school_dict["afstand_m"] = round(afstand)
-            results.append(school_dict)
+            candidates.append((s, round(afstand)))
+
+    if not candidates:
+        return []
+
+    # ORS routeafstanden ophalen
+    ors = _get_ors_collector()
+    destinations = [(s.lat, s.lng) for s, _ in candidates]
+    try:
+        ors_resultaten = ors.get_afstanden(lat, lng, destinations)
+    except Exception as exc:
+        logger.warning("ORS afstandsberekening voor scholen gefaald: %s", exc)
+        ors_resultaten = None
+
+    results = []
+    for i, (s, haversine_m) in enumerate(candidates):
+        school_dict = SchoolSummary.model_validate(s).model_dump()
+        if ors_resultaten and i < len(ors_resultaten):
+            ors_r = ors_resultaten[i]
+            school_dict["afstand_m"] = ors_r.afstand_m
+            school_dict["reistijd_min"] = max(1, round(ors_r.reistijd_sec / 60))
+            school_dict["modaliteit"] = ors_r.modaliteit
+        else:
+            school_dict["afstand_m"] = haversine_m
+            school_dict["reistijd_min"] = max(1, round(haversine_m / 83.3))
+            school_dict["modaliteit"] = "lopen"
+        results.append(school_dict)
 
     results.sort(key=lambda x: x["afstand_m"])
     return results[:limit]

--- a/backend/api/voorzieningen.py
+++ b/backend/api/voorzieningen.py
@@ -15,6 +15,7 @@ from collectors import (
     create_osm_overpass_collector,
     create_cycling_collector,
     create_ov_collector,
+    create_ors_matrix_collector,
     geocode_address_pdok,
 )
 
@@ -27,6 +28,7 @@ _nabijheid_collector = None
 _osm_collector = None
 _cycling_collector = None
 _ov_collector = None
+_ors_matrix_collector = None
 _werklocaties = None
 
 
@@ -37,10 +39,18 @@ def _get_nabijheid_collector():
     return _nabijheid_collector
 
 
+def _get_ors_matrix_collector():
+    global _ors_matrix_collector
+    if _ors_matrix_collector is None:
+        _ors_matrix_collector = create_ors_matrix_collector()
+    return _ors_matrix_collector
+
+
 def _get_osm_collector():
     global _osm_collector
     if _osm_collector is None:
-        _osm_collector = create_osm_overpass_collector()
+        ors = _get_ors_matrix_collector()
+        _osm_collector = create_osm_overpass_collector(ors_collector=ors)
     return _osm_collector
 
 
@@ -81,6 +91,9 @@ class VoorzieningItem(BaseModel):
     categorie: str
     afstand_m: int
     looptijd_min: int
+    reistijd_min: int = 0
+    modaliteit: str = "lopen"
+    is_ors_afstand: bool = False
     lat: float
     lng: float
 
@@ -277,12 +290,16 @@ def _build_response(
         osm_collector = _get_osm_collector()
         osm_result = osm_collector.get_voorzieningen(lat, lng, radius_m)
         for v in osm_result.voorzieningen:
+            reistijd_min = max(1, round(v.reistijd_sec / 60)) if v.reistijd_sec else max(1, round(v.afstand_m / 83.3))
             osm_items.append(VoorzieningItem(
                 naam=v.naam,
                 type=v.type,
                 categorie=v.categorie,
                 afstand_m=v.afstand_m,
-                looptijd_min=max(1, round(v.afstand_m / 83.3)),  # 5 km/h
+                looptijd_min=max(1, round(v.afstand_m / 83.3)),  # 5 km/h schatting
+                reistijd_min=reistijd_min,
+                modaliteit=v.modaliteit or "lopen",
+                is_ors_afstand=not v.is_fallback,
                 lat=v.lat,
                 lng=v.lng,
             ))

--- a/backend/collectors/__init__.py
+++ b/backend/collectors/__init__.py
@@ -51,6 +51,11 @@ from collectors.miljoenhuizen_collector import (
     PrijsHistorieEntry,
     create_miljoenhuizen_collector,
 )
+from collectors.ors_matrix_collector import (
+    ORSMatrixCollector,
+    ORSMatrixResult,
+    create_ors_matrix_collector,
+)
 from collectors.osm_overpass_collector import (
     OSMOverpassCollector,
     OverpassResult,
@@ -189,6 +194,10 @@ __all__ = [
     "MiljoenhuizenWoning",
     "PrijsHistorieEntry",
     "create_miljoenhuizen_collector",
+    # ORS Matrix (multimodale afstanden)
+    "ORSMatrixCollector",
+    "ORSMatrixResult",
+    "create_ors_matrix_collector",
     # OSM Overpass
     "OSMOverpassCollector",
     "OverpassResult",

--- a/backend/collectors/ors_matrix_collector.py
+++ b/backend/collectors/ors_matrix_collector.py
@@ -1,0 +1,378 @@
+"""ORS Matrix Collector — multimodale afstandsberekening via OpenRouteService Matrix API.
+
+Berekent routeafstanden en reistijden van één origin naar meerdere destinations.
+Kiest automatisch de modaliteit (lopen, fietsen, auto) op basis van hemelsbreed afstand.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import random
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+import yaml
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path(__file__).parent.parent.parent / "data" / "cache" / "ors_matrix"
+ORS_BASE_URL = "https://api.openrouteservice.org/v2/matrix"
+
+# ORS profile names
+PROFILE_LOPEN = "foot-walking"
+PROFILE_FIETSEN = "cycling-regular"
+PROFILE_AUTO = "driving-car"
+
+# Modaliteit labels (Nederlands)
+MODALITEIT_MAP = {
+    PROFILE_LOPEN: "lopen",
+    PROFILE_FIETSEN: "fietsen",
+    PROFILE_AUTO: "auto",
+}
+
+# Geschatte snelheden voor haversine fallback (m/s)
+FALLBACK_SNELHEID = {
+    PROFILE_LOPEN: 1.39,     # ~5 km/h
+    PROFILE_FIETSEN: 4.17,   # ~15 km/h
+    PROFILE_AUTO: 8.33,      # ~30 km/h (stadsverkeer)
+}
+
+# Promotie: als reistijd te hoog, stap over naar snellere modaliteit
+PROMOTIE_MAP = {
+    PROFILE_LOPEN: PROFILE_FIETSEN,
+    PROFILE_FIETSEN: PROFILE_AUTO,
+    # auto heeft geen promotie
+}
+
+# Default drempels als config niet geladen kan worden
+DEFAULT_DREMPELS = {
+    "lopen": {"max_hemelsbreed_m": 800},
+    "fietsen": {"max_hemelsbreed_m": 5000},
+}
+
+
+def _haversine(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Hemelsbreed afstand in meters."""
+    R = 6371000
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _load_drempels(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Laad ORS drempelwaarden uit scoring.yaml."""
+    if config_path is None:
+        config_path = Path(__file__).parent.parent.parent / "config" / "scoring.yaml"
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        return config.get("ors_drempels", DEFAULT_DREMPELS)
+    except (IOError, yaml.YAMLError):
+        return DEFAULT_DREMPELS
+
+
+@dataclass
+class ORSMatrixResult:
+    """Resultaat voor een enkel origin-destination paar."""
+    dest_index: int
+    dest_lat: float
+    dest_lng: float
+    afstand_m: int
+    reistijd_sec: int
+    modaliteit: str          # "lopen", "fietsen", "auto"
+    is_fallback: bool        # True als haversine gebruikt werd
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "dest_index": self.dest_index,
+            "dest_lat": self.dest_lat,
+            "dest_lng": self.dest_lng,
+            "afstand_m": self.afstand_m,
+            "reistijd_sec": self.reistijd_sec,
+            "modaliteit": self.modaliteit,
+            "is_fallback": self.is_fallback,
+        }
+
+
+@dataclass
+class ORSMatrixCollector:
+    """Collector voor multimodale afstanden via ORS Matrix API."""
+
+    api_key: str = ""
+    cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
+    cache_days: int = 7
+    min_delay: float = 1.5
+    max_delay: float = 2.5
+    session: Optional[requests.Session] = None
+    drempels: Optional[Dict[str, Any]] = None
+    _last_request: float = field(default=0.0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            self.api_key = os.environ.get("ORS_API_KEY", "")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if self.session is None:
+            self.session = requests.Session()
+            self.session.headers.update({
+                "Authorization": self.api_key,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            })
+        if self.drempels is None:
+            self.drempels = _load_drempels()
+
+    def _rate_limit(self) -> None:
+        elapsed = time.time() - self._last_request
+        delay = random.uniform(self.min_delay, self.max_delay)
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+        self._last_request = time.time()
+
+    def _bepaal_profile(self, hemelsbreed_m: float) -> str:
+        """Kies ORS profile op basis van hemelsbreed afstand."""
+        lopen_max = self.drempels.get("lopen", {}).get("max_hemelsbreed_m", 800)
+        fietsen_max = self.drempels.get("fietsen", {}).get("max_hemelsbreed_m", 5000)
+
+        if hemelsbreed_m < lopen_max:
+            return PROFILE_LOPEN
+        elif hemelsbreed_m < fietsen_max:
+            return PROFILE_FIETSEN
+        else:
+            return PROFILE_AUTO
+
+    def _max_reistijd_sec(self, profile: str) -> Optional[int]:
+        """Max reistijd in seconden voor een profile, of None als geen limiet."""
+        profile_naar_key = {
+            PROFILE_LOPEN: "lopen",
+            PROFILE_FIETSEN: "fietsen",
+        }
+        key = profile_naar_key.get(profile)
+        if not key:
+            return None
+        max_min = self.drempels.get(key, {}).get("max_reistijd_min")
+        return int(max_min * 60) if max_min else None
+
+    def _cache_key(self, profile: str, origin: Tuple[float, float],
+                   destinations: List[Tuple[int, float, float]]) -> str:
+        """Genereer cache key voor een matrix request."""
+        o_lat = round(origin[0], 3)
+        o_lng = round(origin[1], 3)
+        dest_parts = sorted(f"{round(d[1], 4)},{round(d[2], 4)}" for d in destinations)
+        raw = f"{profile}_{o_lat},{o_lng}_{'|'.join(dest_parts)}"
+        return hashlib.md5(raw.encode()).hexdigest()
+
+    def _load_from_cache(self, key: str) -> Optional[Dict]:
+        cache_file = self.cache_dir / f"{key}.json"
+        if not cache_file.exists():
+            return None
+        try:
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+            if data.get("_cached_at", 0) + (self.cache_days * 86400) < time.time():
+                return None
+            return data
+        except (json.JSONDecodeError, IOError):
+            return None
+
+    def _save_to_cache(self, key: str, data: Dict) -> None:
+        data["_cached_at"] = time.time()
+        cache_file = self.cache_dir / f"{key}.json"
+        try:
+            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        except IOError:
+            pass
+
+    def _fallback_result(self, dest_index: int, dest_lat: float, dest_lng: float,
+                         origin_lat: float, origin_lng: float, profile: str) -> ORSMatrixResult:
+        """Haversine fallback voor als ORS niet beschikbaar is."""
+        hemelsbreed = _haversine(origin_lat, origin_lng, dest_lat, dest_lng)
+        # Routeafstand is typisch 1.3x hemelsbreed
+        afstand_m = int(hemelsbreed * 1.3)
+        snelheid = FALLBACK_SNELHEID.get(profile, 1.39)
+        reistijd_sec = int(afstand_m / snelheid)
+        return ORSMatrixResult(
+            dest_index=dest_index,
+            dest_lat=dest_lat,
+            dest_lng=dest_lng,
+            afstand_m=afstand_m,
+            reistijd_sec=reistijd_sec,
+            modaliteit=MODALITEIT_MAP.get(profile, "lopen"),
+            is_fallback=True,
+        )
+
+    def _matrix_request(
+        self,
+        profile: str,
+        origin: Tuple[float, float],
+        destinations: List[Tuple[int, float, float]],
+    ) -> List[ORSMatrixResult]:
+        """Doe een ORS Matrix API request voor één profile.
+
+        Args:
+            profile: ORS profile (foot-walking, cycling-regular, driving-car)
+            origin: (lat, lng) van het startpunt
+            destinations: lijst van (orig_index, lat, lng) tuples
+        """
+        if not destinations:
+            return []
+
+        cache_key = self._cache_key(profile, origin, destinations)
+        cached = self._load_from_cache(cache_key)
+        if cached and "results" in cached:
+            results = []
+            for r in cached["results"]:
+                results.append(ORSMatrixResult(
+                    dest_index=r["dest_index"],
+                    dest_lat=r["dest_lat"],
+                    dest_lng=r["dest_lng"],
+                    afstand_m=r["afstand_m"],
+                    reistijd_sec=r["reistijd_sec"],
+                    modaliteit=r["modaliteit"],
+                    is_fallback=r["is_fallback"],
+                ))
+            return results
+
+        if not self.api_key:
+            return [
+                self._fallback_result(idx, lat, lng, origin[0], origin[1], profile)
+                for idx, lat, lng in destinations
+            ]
+
+        self._rate_limit()
+
+        # ORS verwacht [lng, lat] formaat
+        locations = [[origin[1], origin[0]]]
+        for _, lat, lng in destinations:
+            locations.append([lng, lat])
+
+        body = {
+            "locations": locations,
+            "sources": [0],
+            "destinations": list(range(1, len(locations))),
+            "metrics": ["distance", "duration"],
+        }
+
+        try:
+            resp = self.session.post(
+                f"{ORS_BASE_URL}/{profile}",
+                json=body,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as exc:
+            logger.warning("ORS Matrix request failed (%s): %s", profile, exc)
+            return [
+                self._fallback_result(idx, lat, lng, origin[0], origin[1], profile)
+                for idx, lat, lng in destinations
+            ]
+
+        distances = data.get("distances", [[]])[0]
+        durations = data.get("durations", [[]])[0]
+        modaliteit = MODALITEIT_MAP.get(profile, "lopen")
+
+        results: List[ORSMatrixResult] = []
+        for i, (orig_idx, lat, lng) in enumerate(destinations):
+            dist = distances[i] if i < len(distances) else None
+            dur = durations[i] if i < len(durations) else None
+
+            if dist is None or dur is None:
+                results.append(self._fallback_result(orig_idx, lat, lng, origin[0], origin[1], profile))
+            else:
+                results.append(ORSMatrixResult(
+                    dest_index=orig_idx,
+                    dest_lat=lat,
+                    dest_lng=lng,
+                    afstand_m=int(dist),
+                    reistijd_sec=int(dur),
+                    modaliteit=modaliteit,
+                    is_fallback=False,
+                ))
+
+        # Cache opslaan
+        cache_data = {"results": [r.to_dict() for r in results]}
+        self._save_to_cache(cache_key, cache_data)
+
+        return results
+
+    def get_afstanden(
+        self,
+        origin_lat: float,
+        origin_lng: float,
+        destinations: List[Tuple[float, float]],
+    ) -> List[ORSMatrixResult]:
+        """Bereken multimodale afstanden van origin naar meerdere destinations.
+
+        Args:
+            origin_lat, origin_lng: Startpunt coördinaten
+            destinations: Lijst van (lat, lng) tuples
+
+        Returns:
+            Lijst van ORSMatrixResult, gesorteerd op dest_index (originele volgorde)
+        """
+        if not destinations:
+            return []
+
+        origin = (origin_lat, origin_lng)
+
+        # Groepeer destinations per modaliteit
+        groepen: Dict[str, List[Tuple[int, float, float]]] = {}
+        for i, (lat, lng) in enumerate(destinations):
+            hemelsbreed = _haversine(origin_lat, origin_lng, lat, lng)
+            profile = self._bepaal_profile(hemelsbreed)
+            groepen.setdefault(profile, []).append((i, lat, lng))
+
+        # Per groep een matrix request
+        alle_resultaten: Dict[int, ORSMatrixResult] = {}
+        for profile, dests in groepen.items():
+            # ORS Matrix API max 50 destinations per request
+            for batch_start in range(0, len(dests), 49):
+                batch = dests[batch_start:batch_start + 49]
+                resultaten = self._matrix_request(profile, origin, batch)
+                for r in resultaten:
+                    alle_resultaten[r.dest_index] = r
+
+        # Herclassificatie: promoveer naar snellere modaliteit als reistijd te hoog
+        # Bijv. lopen > 10 min → herberekenen als fietsen
+        # Werkt ook op fallback-resultaten zodat geschatte tijden correct gecategoriseerd worden
+        te_promoveren: Dict[str, List[Tuple[int, float, float]]] = {}
+        for idx, r in alle_resultaten.items():
+            profile = next(
+                (p for p, label in MODALITEIT_MAP.items() if label == r.modaliteit),
+                None,
+            )
+            if not profile:
+                continue
+            max_sec = self._max_reistijd_sec(profile)
+            next_profile = PROMOTIE_MAP.get(profile)
+            if max_sec and next_profile and r.reistijd_sec > max_sec:
+                te_promoveren.setdefault(next_profile, []).append(
+                    (idx, r.dest_lat, r.dest_lng)
+                )
+
+        # Herberekening voor gepromoveerde POIs
+        for profile, dests in te_promoveren.items():
+            for batch_start in range(0, len(dests), 49):
+                batch = dests[batch_start:batch_start + 49]
+                resultaten = self._matrix_request(profile, origin, batch)
+                for r in resultaten:
+                    alle_resultaten[r.dest_index] = r
+
+        # Sorteer op originele index
+        return [alle_resultaten[i] for i in sorted(alle_resultaten.keys())]
+
+
+def create_ors_matrix_collector(cache_dir: Optional[Path] = None) -> ORSMatrixCollector:
+    """Factory function met default cache directory."""
+    if cache_dir is None:
+        cache_dir = CACHE_DIR
+    return ORSMatrixCollector(cache_dir=cache_dir)

--- a/backend/collectors/osm_overpass_collector.py
+++ b/backend/collectors/osm_overpass_collector.py
@@ -105,6 +105,9 @@ class Voorziening:
     afstand_m: int
     lat: float
     lng: float
+    reistijd_sec: int = 0       # ORS reistijd in seconden
+    modaliteit: str = ""        # "lopen", "fietsen", "auto"
+    is_fallback: bool = False   # True als haversine i.p.v. ORS
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -114,6 +117,9 @@ class Voorziening:
             "afstand_m": self.afstand_m,
             "lat": self.lat,
             "lng": self.lng,
+            "reistijd_sec": self.reistijd_sec,
+            "modaliteit": self.modaliteit,
+            "is_fallback": self.is_fallback,
         }
 
     @classmethod
@@ -125,6 +131,9 @@ class Voorziening:
             afstand_m=data["afstand_m"],
             lat=data["lat"],
             lng=data["lng"],
+            reistijd_sec=data.get("reistijd_sec", 0),
+            modaliteit=data.get("modaliteit", ""),
+            is_fallback=data.get("is_fallback", False),
         )
 
 
@@ -163,6 +172,7 @@ class OSMOverpassCollector:
     cache_dir: Path = field(default_factory=lambda: CACHE_DIR)
     cache_days: int = 7
     session: Optional[requests.Session] = None
+    ors_collector: Optional[Any] = None  # ORSMatrixCollector voor routeafstanden
     _last_request: float = field(default=0.0, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -209,6 +219,25 @@ class OSMOverpassCollector:
         except IOError:
             pass
 
+    def _verrijk_met_ors(self, lat: float, lng: float, voorzieningen: List[Voorziening]) -> None:
+        """Verrijk voorzieningen met ORS routeafstanden (in-place)."""
+        if not self.ors_collector or not voorzieningen:
+            return
+        try:
+            destinations = [(v.lat, v.lng) for v in voorzieningen]
+            ors_resultaten = self.ors_collector.get_afstanden(lat, lng, destinations)
+            for v, ors in zip(voorzieningen, ors_resultaten):
+                v.afstand_m = ors.afstand_m
+                v.reistijd_sec = ors.reistijd_sec
+                v.modaliteit = ors.modaliteit
+                v.is_fallback = ors.is_fallback
+            voorzieningen.sort(key=lambda v: v.afstand_m)
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "ORS verrijking gefaald, haversine behouden: %s", exc
+            )
+
     def get_voorzieningen(self, lat: float, lng: float, radius_m: int = 1500) -> OverpassResult:
         """Fetch nearby facilities for given coordinates.
 
@@ -223,6 +252,12 @@ class OSMOverpassCollector:
         cache_key = self._cache_key(lat, lng, radius_m)
         cached = self._load_from_cache(cache_key)
         if cached is not None:
+            # Verrijk gecachete resultaten met ORS als dat nog niet gebeurd is
+            if self.ors_collector and cached.voorzieningen:
+                needs_ors = any(not v.modaliteit for v in cached.voorzieningen)
+                if needs_ors:
+                    self._verrijk_met_ors(lat, lng, cached.voorzieningen)
+                    self._save_to_cache(cache_key, cached)
             return cached
 
         self._rate_limit()
@@ -280,6 +315,8 @@ class OSMOverpassCollector:
 
         voorzieningen.sort(key=lambda v: v.afstand_m)
 
+        self._verrijk_met_ors(lat, lng, voorzieningen)
+
         result = OverpassResult(
             lat=lat,
             lng=lng,
@@ -290,8 +327,17 @@ class OSMOverpassCollector:
         return result
 
 
-def create_osm_overpass_collector(cache_dir: Optional[Path] = None) -> OSMOverpassCollector:
-    """Factory function with default cache directory."""
+def create_osm_overpass_collector(
+    cache_dir: Optional[Path] = None,
+    ors_collector: Optional[Any] = None,
+) -> OSMOverpassCollector:
+    """Factory function with default cache directory.
+
+    Args:
+        cache_dir: Cache directory override.
+        ors_collector: Optionele ORSMatrixCollector voor routeafstanden.
+            Als None, worden haversine afstanden gebruikt.
+    """
     if cache_dir is None:
         cache_dir = Path(__file__).parent.parent.parent / "data" / "cache" / "osm_overpass"
-    return OSMOverpassCollector(cache_dir=cache_dir)
+    return OSMOverpassCollector(cache_dir=cache_dir, ors_collector=ors_collector)

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -1,4 +1,15 @@
 # Scoring configuration for neighborhood analysis
+
+# ORS (OpenRouteService) multimodale afstandsdrempels
+# Bepaalt welke modaliteit gebruikt wordt op basis van hemelsbreed afstand
+ors_drempels:
+  lopen:
+    max_hemelsbreed_m: 800       # < 800m hemelsbreed → foot-walking
+    max_reistijd_min: 10         # > 10 min lopen → promoveer naar fietsen
+  fietsen:
+    max_hemelsbreed_m: 5000      # < 5000m hemelsbreed → cycling-regular
+    max_reistijd_min: 30         # > 30 min fietsen → promoveer naar auto
+  # alles >= 5000m hemelsbreed → driving-car
 # Each indicator has a weight and direction
 # Column names reference indicator keys from collectors, not raw CBS column names
 

--- a/frontend/src/components/VoorzieningenPanel.tsx
+++ b/frontend/src/components/VoorzieningenPanel.tsx
@@ -120,6 +120,18 @@ function CBSAfstandenSection({ afstanden }: { afstanden: Record<string, CBSAfsta
   )
 }
 
+const MODALITEIT_ICONS: Record<string, string> = {
+  lopen: '\u{1F6B6}',
+  fietsen: '\u{1F6B2}',
+  auto: '\u{1F697}',
+}
+
+function reistijdLabel(item: VoorzieningItem): string {
+  const min = item.reistijd_min || item.looptijd_min
+  const icon = MODALITEIT_ICONS[item.modaliteit] || MODALITEIT_ICONS.lopen
+  return `${icon} ${min} min`
+}
+
 function OSMLocatiesSection({ voorzieningen }: { voorzieningen: VoorzieningItem[] }) {
   const [openCategorie, setOpenCategorie] = useState<string | null>(null)
 
@@ -155,7 +167,7 @@ function OSMLocatiesSection({ voorzieningen }: { voorzieningen: VoorzieningItem[
                 <div key={idx} className="flex justify-between items-center text-xs py-1 border-t border-gray-100 first:border-0">
                   <span className="text-gray-700 truncate mr-2" title={item.naam}>{item.naam}</span>
                   <span className={`px-1.5 py-0.5 rounded whitespace-nowrap ${afstandMKleur(item.afstand_m)}`}>
-                    {item.afstand_m}m ({item.looptijd_min} min)
+                    {item.afstand_m}m &middot; {reistijdLabel(item)}
                   </span>
                 </div>
               ))}
@@ -405,7 +417,7 @@ function VoorzieningenKaart({ data }: { data: VoorzieningenResponse }) {
               <div className="text-xs">
                 <div className="font-medium">{v.naam}</div>
                 <div className="text-gray-500">{CATEGORIE_LABELS[v.categorie] || v.categorie}</div>
-                <div>{v.afstand_m}m ({v.looptijd_min} min lopen)</div>
+                <div>{v.afstand_m}m &middot; {reistijdLabel(v)}</div>
               </div>
             </Popup>
           </CircleMarker>
@@ -527,7 +539,7 @@ export default function VoorzieningenPanel({ postcode, huisnummer }: Voorziening
       <VoorzieningenKaart data={data} />
 
       <p className="text-xs text-gray-400">
-        Bronnen: CBS Nabijheid voorzieningen, OpenStreetMap, OpenRouteService, OVapi.nl. Afstanden zijn hemelsbreed (CBS), fietsroute (ORS) of geschat (OV).
+        Bronnen: CBS Nabijheid voorzieningen, OpenStreetMap, OpenRouteService, OVapi.nl. CBS-afstanden zijn hemelsbreed. OSM-afstanden zijn routeafstanden via ORS ({'\u{1F6B6}'} lopen, {'\u{1F6B2}'} fietsen, {'\u{1F697}'} auto).
       </p>
     </div>
   )

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -714,7 +714,7 @@ export async function fetchScholenNabij(params: {
   lng: number
   radius?: number
   type?: string
-}): Promise<(SchoolSummary & { afstand_m: number })[]> {
+}): Promise<(SchoolSummary & { afstand_m: number; reistijd_min: number; modaliteit: string })[]> {
   const searchParams = new URLSearchParams({
     lat: String(params.lat),
     lng: String(params.lng),
@@ -735,6 +735,9 @@ export interface VoorzieningItem {
   categorie: string
   afstand_m: number
   looptijd_min: number
+  reistijd_min: number
+  modaliteit: string  // "lopen" | "fietsen" | "auto"
+  is_ors_afstand: boolean
   lat: number
   lng: number
 }


### PR DESCRIPTION
## Summary

- Nieuwe `ors_matrix_collector` die de ORS Matrix API gebruikt voor batch-afstandsberekening naar meerdere POIs tegelijk
- Automatische modaliteitskeuze: 🚶 lopen (<800m), 🚲 fietsen (<5km), 🚗 auto (>5km) — configureerbaar in `config/scoring.yaml`
- Herclassificatie: als ORS reistijd te hoog uitvalt (lopen >10 min, fietsen >30 min), wordt de POI automatisch gepromoveerd naar de snellere modaliteit
- Haversine fallback zonder `ORS_API_KEY` (backward compatible)
- Frontend toont modaliteit-emoji en reistijd per voorziening

## Gewijzigde bestanden

| Bestand | Wijziging |
|---------|-----------|
| `backend/collectors/ors_matrix_collector.py` | **Nieuw** — ORS Matrix collector |
| `backend/collectors/osm_overpass_collector.py` | ORS verrijking van POI-afstanden |
| `backend/api/voorzieningen.py` | Response model + ORS integratie |
| `backend/api/scholen.py` | ORS routeafstanden voor nabije scholen |
| `backend/collectors/__init__.py` | Exports |
| `config/scoring.yaml` | Configureerbare drempels |
| `frontend/src/services/api.ts` | TypeScript interfaces |
| `frontend/src/components/VoorzieningenPanel.tsx` | Modaliteit emoji + reistijd |

## Test plan

- [x] API test: `curl localhost:8000/api/voorzieningen/adres?postcode=2632AT&huisnummer=37` — voorzieningen met `modaliteit`, `reistijd_min`, `is_ors_afstand`
- [x] Fallback: zonder `ORS_API_KEY` werkt alles met haversine-schattingen
- [x] Promotie: POIs met looptijd >10 min verschijnen als 🚲 fietsen
- [x] Frontend: emoji's en reistijden zichtbaar in voorzieningen panel
- [x] Scholen: `GET /api/scholen/nabij?lat=52.05&lng=4.40` bevat `reistijd_min` en `modaliteit`

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)